### PR TITLE
HUB-96: Login/logout destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Logo link to www.helsinki.fi (HUB-108)
 * Remove links from news degree programme field (HUB-108)
 * Fixed error when having an unknown degree programme in cookies
+* Return the user to the location where the login was done (HUB-96)
 
 
 ## 1.0-beta0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -60,6 +60,7 @@ module:
   uhsg_feedback: 0
   uhsg_migrate: 0
   uhsg_news: 0
+  uhsg_samlauth: 0
   uhsg_search: 0
   uhsg_service_provider_details: 0
   uhsg_some_links: 0

--- a/modules/uhsg_samlauth/src/Controller/SamlController.php
+++ b/modules/uhsg_samlauth/src/Controller/SamlController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\uhsg_samlauth\Controller;
+
+use Drupal\Core\Path\PathValidator;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\samlauth\Controller\SamlController as OriginalSamlController;
+use Drupal\uhsg_samlauth\SamlService;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class SamlController extends OriginalSamlController {
+
+  /**
+   * @var Request
+   */
+  protected $request;
+
+  /**
+   * @var PathValidator
+   */
+  protected $pathValidator;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(SamlService $saml) {
+    $this->saml = $saml;
+    parent::__construct($saml);
+
+    // TODO: Why I can't inject these from constructor? Is it because
+    // constructor signature differs from the original constructor?
+    $this->saml->setRequest(\Drupal::request());
+    $this->saml->setPathValidator(\Drupal::pathValidator());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function login() {
+    $this->saml->setPostLoginLogoutDestination();
+    parent::login();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function logout() {
+    $this->saml->setPostLoginLogoutDestination();
+    parent::logout();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function acs() {
+    try {
+      $this->saml->acs();
+    }
+    catch (Exception $e) {
+      drupal_set_message($e->getMessage(), 'error');
+      return new RedirectResponse('/');
+    }
+
+    $url = $this->saml->getPostLoginDestination()->toString(TRUE);
+    $response = new TrustedRedirectResponse($url->getGeneratedUrl());
+    $response->addCacheableDependency($url);
+    return $response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sls() {
+    $this->saml->sls();
+
+    $url = $this->saml->getPostLoginDestination()->toString(TRUE);
+    $response = new TrustedRedirectResponse($url->getGeneratedUrl());
+    $response->addCacheableDependency($url);
+    return $response;
+  }
+
+}

--- a/modules/uhsg_samlauth/src/Controller/SamlController.php
+++ b/modules/uhsg_samlauth/src/Controller/SamlController.php
@@ -65,6 +65,7 @@ class SamlController extends OriginalSamlController {
     $url = $this->saml->getPostLoginDestination()->toString(TRUE);
     $response = new TrustedRedirectResponse($url->getGeneratedUrl());
     $response->addCacheableDependency($url);
+    $this->saml->removePostLoginLogoutDestination();
     return $response;
   }
 
@@ -77,6 +78,7 @@ class SamlController extends OriginalSamlController {
     $url = $this->saml->getPostLoginDestination()->toString(TRUE);
     $response = new TrustedRedirectResponse($url->getGeneratedUrl());
     $response->addCacheableDependency($url);
+    $this->saml->removePostLoginLogoutDestination();
     return $response;
   }
 

--- a/modules/uhsg_samlauth/src/Controller/SamlController.php
+++ b/modules/uhsg_samlauth/src/Controller/SamlController.php
@@ -57,7 +57,7 @@ class SamlController extends OriginalSamlController {
     try {
       $this->saml->acs();
     }
-    catch (Exception $e) {
+    catch (\Exception $e) {
       drupal_set_message($e->getMessage(), 'error');
       return new RedirectResponse('/');
     }

--- a/modules/uhsg_samlauth/src/Routing/RouteSubscriber.php
+++ b/modules/uhsg_samlauth/src/Routing/RouteSubscriber.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\uhsg_samlauth\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+class RouteSubscriber extends RouteSubscriberBase {
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    // Replace saml login with own implementation that has additional features
+    if ($route = $collection->get('samlauth.saml_controller_login')) {
+      $route->setDefault('_controller', 'Drupal\\uhsg_samlauth\\Controller\\SamlController::login');
+    }
+  }
+}

--- a/modules/uhsg_samlauth/src/Routing/RouteSubscriber.php
+++ b/modules/uhsg_samlauth/src/Routing/RouteSubscriber.php
@@ -10,7 +10,7 @@ class RouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   public function alterRoutes(RouteCollection $collection) {
-    // Replace saml login with own implementation that has additional features
+    // Replace saml login with own implementation that has additional features.
     if ($route = $collection->get('samlauth.saml_controller_login')) {
       $route->setDefault('_controller', 'Drupal\\uhsg_samlauth\\Controller\\SamlController::login');
     }

--- a/modules/uhsg_samlauth/src/SamlService.php
+++ b/modules/uhsg_samlauth/src/SamlService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\uhsg_samlauth;
+
+use Drupal\Core\Path\PathValidator;
+use Drupal\Core\Url;
+use Drupal\samlauth\SamlService as OriginalSamlService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class SamlService extends OriginalSamlService {
+
+  const SESS_VALUE_KEY = 'postLoginLogoutDestination';
+
+  /**
+   * @var Request
+   */
+  protected $request;
+
+  /**
+   * @var PathValidator
+   */
+  protected $pathValidator;
+
+  /**
+   * @param Request $request
+   */
+  public function setRequest(Request $request) {
+    $this->request = $request;
+  }
+
+  /**
+   * @param PathValidator $pathValidator
+   */
+  public function setPathValidator(PathValidator $pathValidator) {
+    $this->pathValidator = $pathValidator;
+  }
+
+  /**
+   * Set login and logout destinations in user´s session.
+   */
+  public function setPostLoginLogoutDestination() {
+
+    // Get session and create one if not exit
+    if (!$this->request->hasSession()) {
+      $this->request->setSession(new Session());
+    }
+
+    // Primarly get url from referrer if it is valid or else use front page.
+    $referer = $this->request->server->get('HTTP_REFERER');
+    $url = new Url('<front>');
+    if ($referer) {
+      if ($valid_url = $this->pathValidator->getUrlIfValid($referer)) {
+        $url = $valid_url;
+      }
+    }
+
+    // Store serialized URL into session
+    $session = $this->request->getSession();
+    $session->set(self::SESS_VALUE_KEY, serialize($url));
+    $session->save();
+  }
+
+  /**
+   * Get login and logout destinations in user´s session.
+   *
+   * @return Url|null
+   */
+  public function getPostLoginLogoutDestination() {
+    if ($this->request->hasSession() && !empty($this->request->getSession()->get(self::SESS_VALUE_KEY))) {
+      return unserialize($this->request->getSession()->get(self::SESS_VALUE_KEY));
+    }
+    return NULL;
+  }
+
+  /**
+   * Removes post login/logout destination from existing session. Nothing is
+   * done if request has no session.
+   */
+  public function removePostLoginLogoutDestination() {
+    if ($this->request->hasSession()) {
+      foreach ($this->request->getSession()->all() as $key => $value) {
+        if ($key == self::SESS_VALUE_KEY) {
+          $this->request->getSession()->remove(self::SESS_VALUE_KEY);
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPostLoginDestination() {
+    return $this->getPostLoginLogoutDestination();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPostLogoutDestination() {
+    return $this->getPostLoginLogoutDestination();
+  }
+
+}

--- a/modules/uhsg_samlauth/src/SamlService.php
+++ b/modules/uhsg_samlauth/src/SamlService.php
@@ -41,12 +41,12 @@ class SamlService extends OriginalSamlService {
    */
   public function setPostLoginLogoutDestination() {
 
-    // Get session and create one if not exit
+    // Get session. Create the session if it does not exist.
     if (!$this->request->hasSession()) {
       $this->request->setSession(new Session());
     }
 
-    // Primarly get url from referrer if it is valid or else use front page.
+    // Get the URL from the referer if it is valid or else use front page.
     $referer = $this->request->server->get('HTTP_REFERER');
     $url = new Url('<front>');
     if ($referer) {
@@ -55,7 +55,7 @@ class SamlService extends OriginalSamlService {
       }
     }
 
-    // Store serialized URL into session
+    // Store the serialized URL into session.
     $session = $this->request->getSession();
     $session->set(self::SESS_VALUE_KEY, serialize($url));
     $session->save();

--- a/modules/uhsg_samlauth/src/UhsgSamlauthServiceProvider.php
+++ b/modules/uhsg_samlauth/src/UhsgSamlauthServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\uhsg_samlauth;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Modify the SamlAuth service with an overridden/extended service.
+ */
+class UhsgSamlauthServiceProvider extends ServiceProviderBase {
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $definition = $container->getDefinition('samlauth.saml');
+    $definition->setClass('Drupal\uhsg_samlauth\SamlService');
+  }
+}

--- a/modules/uhsg_samlauth/uhsg_samlauth.info.yml
+++ b/modules/uhsg_samlauth/uhsg_samlauth.info.yml
@@ -1,0 +1,8 @@
+name: SAML2 Authentication for Guide
+type: module
+description: Adds additional logic on top of the original SAML2 Authentication module.
+core: 8.x
+version: VERSION
+package: Student Guide
+dependencies:
+  - samlauth

--- a/modules/uhsg_samlauth/uhsg_samlauth.services.yml
+++ b/modules/uhsg_samlauth/uhsg_samlauth.services.yml
@@ -1,0 +1,5 @@
+services:
+  uhsg_samlauth.route_subscriber:
+    class: Drupal\uhsg_samlauth\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/student_guide.info.yml
+++ b/student_guide.info.yml
@@ -32,6 +32,7 @@ dependencies:
   - uhsg_feedback
   - uhsg_news
   - uhsg_service_provider_details
+  - uhsg_samlauth
   - uhsg_some_links
   - uhsg_themes
   - views


### PR DESCRIPTION
This feature should always redirect back to the page where use used to be before logging in.

* Uses SAML Auth module as base for the functionality
* Swaps the original service to own service
* Swaps the origianl controller to own controller
* Own service has additional features for storing/reading and clearing the path where user comes from
* Own controller uses own overrided service that has features to deliver/control the redirect destinations