### PR TITLE
DOO-56: Do not allow (un)flagging for technical flags

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -61,6 +61,7 @@ module:
   uhsg_active_degree_programme: 0
   uhsg_article: 0
   uhsg_cookie_consent: 0
+  uhsg_degree_programme: 0
   uhsg_edit: 0
   uhsg_feedback: 0
   uhsg_migrate: 0

--- a/config/sync/uhsg_degree_programme.settings.yml
+++ b/config/sync/uhsg_degree_programme.settings.yml
@@ -1,0 +1,3 @@
+technical_condition_field_name: field_applied_by_study_rights
+_core:
+  default_config_hash: _NMHnNRw_MoQO7UIv7dHGiMlk1QKaIPo0u_SxAs04VE

--- a/modules/uhsg_degree_programme/config/install/uhsg_degree_programme.settings.yml
+++ b/modules/uhsg_degree_programme/config/install/uhsg_degree_programme.settings.yml
@@ -1,0 +1,1 @@
+technical_condition_field_name: 'field_applied_by_study_rights'

--- a/modules/uhsg_degree_programme/config/schema/uhsg_degree_programme.settings.schema.yml
+++ b/modules/uhsg_degree_programme/config/schema/uhsg_degree_programme.settings.schema.yml
@@ -1,0 +1,9 @@
+# Schema for the configuration files of the degree programme module.
+
+uhsg_degree_programme.settings:
+  type: config_object
+  label: 'User Sync settings'
+  mapping:
+    technical_condition_field_name:
+      type: string
+      label: 'Field name that indicates the flagging being programmatically managed.'

--- a/modules/uhsg_degree_programme/config/schema/uhsg_degree_programme.settings.schema.yml
+++ b/modules/uhsg_degree_programme/config/schema/uhsg_degree_programme.settings.schema.yml
@@ -2,7 +2,7 @@
 
 uhsg_degree_programme.settings:
   type: config_object
-  label: 'User Sync settings'
+  label: 'Degree Programme settings'
   mapping:
     technical_condition_field_name:
       type: string

--- a/modules/uhsg_degree_programme/src/Flag/MyDegreeProgrammeFlagType.php
+++ b/modules/uhsg_degree_programme/src/Flag/MyDegreeProgrammeFlagType.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\uhsg_degree_programme\Flag;
+
+use Drupal\Core\Access\AccessResultForbidden;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\flag\FlagInterface;
+use Drupal\flag\FlagServiceInterface;
+use Drupal\flag\Plugin\Flag\EntityFlagType;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This class overrides EntityFlagType so that we can override the actionAccess
+ * to follow business logic we want.
+ */
+class MyDegreeProgrammeFlagType extends EntityFlagType {
+
+  /**
+   * Specify the flag id where we want to apply this specific business logic.
+   * @var string
+   */
+  protected $apply_custom_access_logic_id = 'my_degree_programmes';
+
+  /**
+   * @var FlagServiceInterface
+   */
+  protected $flagService;
+
+  /**
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_type_manager, FlagServiceInterface $flagService, ConfigFactoryInterface $configFactory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $module_handler, $entity_type_manager);
+    $this->flagService = $flagService;
+    $this->config = $configFactory->get('uhsg_degree_programme.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('module_handler'),
+      $container->get('entity_type.manager'),
+      $container->get('flag'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function actionAccess($action, FlagInterface $flag, AccountInterface $account, EntityInterface $flaggable = NULL) {
+    $access = parent::actionAccess($action, $flag, $account, $flaggable);
+
+    // When specified flag type, then introduce some additional access logic
+    if ($flag->id() == $this->apply_custom_access_logic_id && !is_null($flaggable)) {
+      // Get the flagging and deny access if the flagging has been created
+      // programmatically.
+      if ($flagging = $this->flagService->getFlagging($flag, $flaggable, $account)) {
+        if ($flagging->hasField($this->config->get('technical_condition_field_name')) &&
+            !$flagging->get($this->config->get('technical_condition_field_name'))->isEmpty() &&
+            $flagging->get($this->config->get('technical_condition_field_name'))->first()->getValue()['value']) {
+          $access = $access->andIf(new AccessResultForbidden());
+        }
+      }
+    }
+
+    return $access;
+  }
+}

--- a/modules/uhsg_degree_programme/uhsg_degree_programme.flag.inc
+++ b/modules/uhsg_degree_programme/uhsg_degree_programme.flag.inc
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Implements hook_flag_type_info_alter().
+ */
+function uhsg_degree_programme_flag_type_info_alter(array &$definitions) {
+  if (isset($definitions['entity:taxonomy_term'])) {
+    $definitions['entity:taxonomy_term']['class'] = '\\Drupal\\uhsg_degree_programme\\Flag\\MyDegreeProgrammeFlagType';
+  }
+}

--- a/modules/uhsg_degree_programme/uhsg_degree_programme.info.yml
+++ b/modules/uhsg_degree_programme/uhsg_degree_programme.info.yml
@@ -1,0 +1,8 @@
+name: Degree programme
+type: module
+description: Provides some improvements and utility features for degree programmes.
+core: 8.x
+version: VERSION
+package: Student Guide
+dependencies:
+  - uhsg_active_degree_programme

--- a/modules/uhsg_degree_programme/uhsg_degree_programme.module
+++ b/modules/uhsg_degree_programme/uhsg_degree_programme.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains uhsg_active_degree_programme.module.
+ * Contains uhsg_degree_programme.module.
  */
 
 use Drupal\views\ViewExecutable;
@@ -10,7 +10,7 @@ use Drupal\views\ViewExecutable;
 /**
  * Implements hook_views_post_execute().
  */
-function uhsg_active_degree_programme_views_post_execute(ViewExecutable $view) {
+function uhsg_degree_programme_views_post_execute(ViewExecutable $view) {
   if ($view->id() == 'search') {
 
     $active_degree_programme_tid = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getId();


### PR DESCRIPTION
* Moved non-activeness degree programme code to new module that holds some functionalities around degree programme (but not directly related to active degree programme)
* Alters & extends `EntityFlagType` to deny acces for flagging/unflagging when flag has been marked to be technical flagging