### PR TITLE
Feature/hub 198 front page changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added some validation related to active degree programme detection mechanism
 * Fixed node preview (HUB-211)
+* Front page visual changes (HUB-198)
 
 
 ## 1.4-dev

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,8 @@
         "2860473-1": "https://www.drupal.org/files/issues/2860473-1.patch"
       },
       "drupal/google_analytics_reports": {
-        "2795115-6-and-2860399-1": "patches/google_analytics_reports.patch"
+        "2795115-6-and-2860399-1": "patches/google_analytics_reports.patch",
+        "2850463-2": "https://www.drupal.org/files/issues/error_when_saving-2850463-2.patch"
       },
       "drupal/flag" : {
         "2846111-4": "https://www.drupal.org/files/issues/broken_ajax_link_views-2846111-4.patch"

--- a/config/sync/views.view.google_analytics_summary.yml
+++ b/config/sync/views.view.google_analytics_summary.yml
@@ -1386,7 +1386,7 @@ display:
         type: html_list
         options:
           grouping: {  }
-          row_class: 'list-of-links__link button--action-before icon--search theme-transparent'
+          row_class: 'list-of-links__link button--action-before theme-transparent'
           default_row_class: true
           type: ul
           wrapper_class: ''

--- a/config/sync/views.view.google_analytics_summary.yml
+++ b/config/sync/views.view.google_analytics_summary.yml
@@ -1387,7 +1387,7 @@ display:
         options:
           grouping: {  }
           row_class: 'list-of-links__link button--action-before theme-transparent'
-          default_row_class: true
+          default_row_class: 1
           type: ul
           wrapper_class: ''
           class: list-of-links__compact
@@ -1401,8 +1401,8 @@ display:
       pager:
         type: some
         options:
-          items_per_page: 5
-          offset: 0
+          items_per_page: '4'
+          offset: '0'
       empty: {  }
       header: {  }
       display_description: ''

--- a/modules/uhsg_search/js/mySearches.js
+++ b/modules/uhsg_search/js/mySearches.js
@@ -38,7 +38,7 @@
           content += '<li class="list-of-links__link button--action-before theme-transparent">' + cleanupString(value) + '</li>';
         });
 
-        var title = '<span>' + Drupal.t('My searches') + '</span>';
+        var title = '<span>' + Drupal.t('My searches') + ':</span>';
         var resetButton = '<a class="button--action icon--remove theme-transparent button--reset" title="' + Drupal.t('Remove') + '"></a>';
         $('#my-searches').empty();
         $('#my-searches').append(title + '<ul class="list-of-links__compact">' + content + resetButton + '</ul>');

--- a/modules/uhsg_search/js/mySearches.js
+++ b/modules/uhsg_search/js/mySearches.js
@@ -35,11 +35,11 @@
       if (mySearches.length) {
         var content = '';
         mySearches.map(function (value) {
-          content += '<li class="list-of-links__link button--action-before icon--search theme-transparent">' + cleanupString(value) + '</li>';
+          content += '<li class="list-of-links__link button--action-before theme-transparent">' + cleanupString(value) + '</li>';
         });
 
-        var title = '<h4>' + Drupal.t('My Searches') + '</h4>';
-        var resetButton = '<a class="button--action icon--remove theme-transparent button--reset">' + Drupal.t('Remove') + '</a>';
+        var title = '<span>' + Drupal.t('My Searches') + '</span>';
+        var resetButton = '<a class="button--action icon--remove theme-transparent button--reset" title="' + Drupal.t('Remove') + '"></a>';
         $('#my-searches').empty();
         $('#my-searches').append(title + '<ul class="list-of-links__compact">' + content + resetButton + '</ul>');
 

--- a/modules/uhsg_search/js/mySearches.js
+++ b/modules/uhsg_search/js/mySearches.js
@@ -38,7 +38,7 @@
           content += '<li class="list-of-links__link button--action-before theme-transparent">' + cleanupString(value) + '</li>';
         });
 
-        var title = '<span>' + Drupal.t('My Searches') + '</span>';
+        var title = '<span>' + Drupal.t('My searches') + '</span>';
         var resetButton = '<a class="button--action icon--remove theme-transparent button--reset" title="' + Drupal.t('Remove') + '"></a>';
         $('#my-searches').empty();
         $('#my-searches').append(title + '<ul class="list-of-links__compact">' + content + resetButton + '</ul>');

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8259,6 +8259,10 @@ h1, h2, h3, h4, legend,
   padding-left: 0;
 }
 
+.view-search .view-header .top-searches .button--action-before.theme-transparent:after {
+  display: none;
+}
+
 .view-search #my-searches {
   padding-top: 2em;
 }

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8265,11 +8265,12 @@ h1, h2, h3, h4, legend,
 
 .view-search #my-searches .list-of-links__link {
   display: inline;
+  padding-left: 0.5em;
 }
 
-@media (max-width: 48em) {
+@media (min-width: 62.5em) {
   .view-search #my-searches .list-of-links__link {
-    padding-left: 0.5em;
+    padding-left: 2em;
   }
 }
 

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8255,12 +8255,51 @@ h1, h2, h3, h4, legend,
   display: none;
 }
 
-.view-search .view-header #my-searches .list-of-links__compact {
+.view-search #my-searches {
+  padding-top: 1em;
+}
+
+.view-search #my-searches .list-of-links__link {
+  display: inline;
+}
+
+@media (max-width: 48em) {
+  .view-search #my-searches .list-of-links__link {
+    padding-left: 0.5em;
+  }
+}
+
+.view-search #my-searches .list-of-links__compact {
+  display: inline;
   margin-bottom: 0;
+}
+
+.view-search #my-searches .button--reset {
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .view-search .view-before-content {
   margin-bottom: 15px;
+}
+
+.view-search #edit-search-api-fulltext {
+  width: 60%;
+}
+
+.view-search #edit-actions {
+  display: inline;
+  white-space: nowrap;
+}
+
+.view-search #edit-submit-search {
+  padding: 0.55em;
+}
+
+.view-search #edit-reset {
+  margin: 0;
+  padding-left: 0.5em;
 }
 
 .ui-autocomplete {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8260,7 +8260,7 @@ h1, h2, h3, h4, legend,
 }
 
 .view-search #my-searches {
-  padding-top: 1em;
+  padding-top: 2em;
 }
 
 .view-search #my-searches .list-of-links__link {
@@ -8288,22 +8288,30 @@ h1, h2, h3, h4, legend,
   margin-bottom: 15px;
 }
 
-.view-search #edit-search-api-fulltext {
-  width: 60%;
+@media (min-width: 48em) {
+  .view-search #edit-search-api-fulltext {
+    width: 60%;
+  }
 }
 
-.view-search #edit-actions {
-  display: inline;
-  white-space: nowrap;
+@media (min-width: 48em) {
+  .view-search #edit-actions {
+    display: inline;
+    white-space: nowrap;
+  }
 }
 
-.view-search #edit-submit-search {
-  padding: 0.55em;
+@media (min-width: 48em) {
+  .view-search #edit-submit-search {
+    padding: 0.55em;
+  }
 }
 
-.view-search #edit-reset {
-  margin: 0;
-  padding-left: 0.5em;
+@media (min-width: 48em) {
+  .view-search #edit-reset {
+    margin: 0;
+    padding-left: 0.5em;
+  }
 }
 
 .ui-autocomplete {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8275,8 +8275,20 @@ h1, h2, h3, h4, legend,
 }
 
 .view-search #my-searches .list-of-links__compact {
-  display: inline;
   margin-bottom: 0;
+}
+
+.view-search #my-searches .list-of-links__compact li:first-child {
+  padding-left: 0;
+}
+
+@media (min-width: 62.5em) {
+  .view-search #my-searches .list-of-links__compact {
+    display: inline;
+  }
+  .view-search #my-searches .list-of-links__compact li:first-child {
+    padding-left: 2em;
+  }
 }
 
 .view-search #my-searches .button--reset {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8255,6 +8255,10 @@ h1, h2, h3, h4, legend,
   display: none;
 }
 
+.view-search .view-header .top-searches .list-of-links__link {
+  padding-left: 0;
+}
+
 .view-search #my-searches {
   padding-top: 1em;
 }

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -48,8 +48,9 @@
     padding-top: 2em;
     .list-of-links__link {
       display: inline;
-      @include breakpoint($mobile-only) {
-        padding-left: 0.5em;
+      padding-left: 0.5em;
+      @include breakpoint($medium) {
+        padding-left: 2em;
       }
     }
     .list-of-links__compact {

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -42,6 +42,9 @@
       .list-of-links__link {
         padding-left: 0;
       }
+      .button--action-before.theme-transparent:after {
+        display: none;
+      }
     }
   }
   #my-searches {

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -45,7 +45,7 @@
     }
   }
   #my-searches {
-    padding-top: 1em;
+    padding-top: 2em;
     .list-of-links__link {
       display: inline;
       @include breakpoint($mobile-only) {
@@ -64,18 +64,26 @@
     margin-bottom: $vert-spacing-unit / 2;
   }
   #edit-search-api-fulltext {
-    width: 60%;
+    @include breakpoint($small) {
+      width: 60%;
+    }
   }
   #edit-actions {
-    display: inline;
-    white-space: nowrap;
+    @include breakpoint($small) {
+      display: inline;
+      white-space: nowrap;
+    }
   }
   #edit-submit-search {
-    padding: 0.55em;
+    @include breakpoint($small) {
+      padding: 0.55em;
+    }
   }
   #edit-reset {
-    margin: 0;
-    padding-left: 0.5em;
+    @include breakpoint($small) {
+      margin: 0;
+      padding-left: 0.5em;
+    }
   }
 }
 

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -54,7 +54,15 @@
       }
     }
     .list-of-links__compact {
-      display: inline;
+      li:first-child {
+        padding-left: 0;
+      }
+      @include breakpoint($medium) {
+        display: inline;
+        li:first-child {
+          padding-left: 2em;
+        }
+      }
       margin-bottom: 0;
     }
     .button--reset {

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -38,12 +38,39 @@
     .top-searches li:last-child {
       display: none;
     }
-    #my-searches .list-of-links__compact {
+  }
+  #my-searches {
+    padding-top: 1em;
+    .list-of-links__link {
+      display: inline;
+      @include breakpoint($mobile-only) {
+        padding-left: 0.5em;
+      }
+    }
+    .list-of-links__compact {
+      display: inline;
       margin-bottom: 0;
+    }
+    .button--reset {
+      display: inline-flex;
     }
   }
   .view-before-content {
     margin-bottom: $vert-spacing-unit / 2;
+  }
+  #edit-search-api-fulltext {
+    width: 60%;
+  }
+  #edit-actions {
+    display: inline;
+    white-space: nowrap;
+  }
+  #edit-submit-search {
+    padding: 0.55em;
+  }
+  #edit-reset {
+    margin: 0;
+    padding-left: 0.5em;
   }
 }
 

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -35,8 +35,13 @@
   }
   .view-header {
     // this empty result can't be removed in the view or in pre_render?
-    .top-searches li:last-child {
-      display: none;
+    .top-searches {
+      li:last-child {
+        display: none;
+      }
+      .list-of-links__link {
+        padding-left: 0;
+      }
     }
   }
   #my-searches {

--- a/themes/uhsg_theme/templates/views/views-view--search.html.twig
+++ b/themes/uhsg_theme/templates/views/views-view--search.html.twig
@@ -56,6 +56,9 @@
           {{ exposed }}
         </div>
       {% endif %}
+      {{ attach_library('uhsg_search/my-searches') }}
+      <div id="my-searches">
+      </div>
     </div>
     <div class="col-right">
       {% if header %}
@@ -64,9 +67,6 @@
             <h4> {{ 'Top content'|trans }} </h4>
             {{ header.view }}
           {% endif %}
-          {{ attach_library('uhsg_search/my-searches') }}
-          <div id="my-searches">
-          </div>
         </div>
       {% endif %}
     </div>

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -48,7 +48,7 @@ msgstr "Sähköposti lähetetty osoitteisiin @email."
 msgid "Email sending failed."
 msgstr "Sähköpostin lähettäminen epäonistui."
 
-msgid "My Searches"
+msgid "My searches"
 msgstr "Omat Haut"
 
 msgid "Top content"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -48,7 +48,7 @@ msgstr ""
 msgid "Email sending failed."
 msgstr ""
 
-msgid "My Searches"
+msgid "My searches"
 msgstr "Mina sökningar"
 
 msgid "Top content"


### PR DESCRIPTION
Front page visual changes:

- Moved My searches from the right column to the main content area
- Restyled My searches to take less screen estate
- Moved search form buttons (on bigger resolutions) to same line to preserve vertical space
- Removed search icon from the top content listing
- Reduced the number of top content listing items from five to four
- Tuned the visuals on smaller resolutions to make things look ok on smaller screens

Testing:

See theme instructions and finally run `npm run gulp browsersync` to enable mobile device testing on localhost (go to the external address, see terminal).