### PR TITLE
HUB-223: Added possibility to use UniTube links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Release date: ??.??.2017
 
 * Changed location of paragraph images (HUB-231)
-* Added possibility to use UniTube video links (HUB-223)
+* Added possibility to use UniTube video links (HUB-233)
 * Added possibility to attach inline images to body fields (HUB-229)
 * Changed location of paragraph videos (HUB-232)
 * Changed feedback recipient email address (HUB-228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Release date: ??.??.2017
 
 * Changed location of paragraph images (HUB-231)
+* Added possibility to use UniTube video links (HUB-223)
 * Added possibility to attach inline images to body fields (HUB-229)
 * Changed location of paragraph videos (HUB-232)
 * Changed feedback recipient email address (HUB-228)

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "drupal/draggableviews": "^1.0",
         "drupal/restui": "^1.14",
         "drupal/edit_own_user_account_permission": "1.x-dev#68b5906f02df22506faf2a8599f063ba76552a78",
-        "UH-StudentServices/video_embed_unitube": "^1.0-alpha1"
+        "UH-StudentServices/video_embed_unitube": "^1.0-alpha1",
+        "drupal/editor_file": "^1.2"
     },
     "repositories": {
         "0": {

--- a/composer.json
+++ b/composer.json
@@ -1,114 +1,131 @@
 {
-  "name": "uh-studentservices/student_guide",
-  "description": "Student Guide installation profile for University of Helsinki.",
-  "type": "drupal-profile",
-  "license": "GPL-3.0",
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "config": {
-    "bin-dir": "bin/"
-  },
-  "require-dev": {
-    "drush/drush": "^8.0",
-    "drupal/drupal-extension": "^3.2",
-    "behat/behat": "^3.0",
-    "drupal/coder": "8.*",
-    "phing/phing": "^2.14",
-    "behat/mink": "~1.7",
-    "behat/mink-goutte-driver": "~1.2",
-    "jcalderonzumba/gastonjs": "~1.0.2",
-    "mikey179/vfsStream": "~1.2",
-    "phpunit/phpunit": "~4.8",
-    "symfony/css-selector": "~2.8",
-    "drupal/devel": "^1.0",
-    "squizlabs/php_codesniffer": "2.*",
-    "se/selenium-server-standalone": "^2.53"
-  },
-  "require": {
-    "cweagans/composer-patches": "^1.5.0",
-    "composer/installers": "^1.0",
-    "drupal/admin_toolbar": "^1.18",
-    "drupal/core": "^8.3",
-    "drupal/paragraphs": "^1.0",
-    "drupal/pathauto": "^1.0-beta2",
-    "drupal/migrate_plus": "^3.0-beta1",
-    "drupal/migrate_source_csv": "^2.0",
-    "drupal/migrate_tools": "^3.0-beta1",
-    "drupal/purge": "^3.0@beta",
-    "drupal/purge_purger_http": "^1.0@beta",
-    "drupal/search_api": "1.x-dev#1a29559f9f09b181e5da4b9becf36ae9a41b9440",
-    "drupal/search_api_solr": "1.x-dev#7cb30ed5ecbe76171438c668abf1d3e9045cfa81",
-    "drupal/search_api_autocomplete": "1.0.0-alpha1",
-    "drupal/contact_ajax": "^1.4@beta",
-    "drupal/contact_block": "^1.3",
-    "drupal/honeypot": "^1.23",
-    "drupal/google_analytics": "2.x-dev#8a3bd1b63764e88ebe1b96fb362a8aec54d912e9",
-    "drupal-composer/drupal-scaffold": "^2.2",
-    "drupal/samlauth": "2.0-alpha0",
-    "drupal/google_analytics_reports": "3.0-beta1",
-    "drupal/video_embed_field": "^1.4",
-    "drupal/noreqnewpass": "1.x-dev#f0d42e42fbac538dcf47d3ff8f5b14000fa19ffd",
-    "drupal/block_access": "dev-8.x-1.x#1cd59ba6856c897afae2551feaa8e6b7f312489c",
-    "drupal/content_lock": "^1.0@alpha",
-    "drupal/flag": "4.0.0-alpha1",
-    "RubaXa/Sortable": "1.4.0",
-    "drupal/facets": "^1.0@alpha",
-    "drupal/config_ignore": "^1.3",
-    "drupal/draggableviews": "^1.0",
-    "drupal/restui": "^1.14",
-    "drupal/edit_own_user_account_permission": "1.x-dev#68b5906f02df22506faf2a8599f063ba76552a78"
-  },
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://packages.drupal.org/8"
+    "name": "uh-studentservices/student_guide",
+    "description": "Student Guide installation profile for University of Helsinki.",
+    "type": "drupal-profile",
+    "license": "GPL-3.0",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "bin-dir": "bin/"
     },
-    {
-      "type": "vcs",
-      "url": "https://github.com/larowlan/block_access"
+    "require-dev": {
+        "drush/drush": "^8.0",
+        "drupal/drupal-extension": "^3.2",
+        "behat/behat": "^3.0",
+        "drupal/coder": "8.*",
+        "phing/phing": "^2.14",
+        "behat/mink": "~1.7",
+        "behat/mink-goutte-driver": "~1.2",
+        "jcalderonzumba/gastonjs": "~1.0.2",
+        "mikey179/vfsStream": "~1.2",
+        "phpunit/phpunit": "~4.8",
+        "symfony/css-selector": "~2.8",
+        "drupal/devel": "^1.0",
+        "squizlabs/php_codesniffer": "2.*",
+        "se/selenium-server-standalone": "^2.53"
     },
-    {
-      "type": "package",
-      "package": {
-        "name": "RubaXa/Sortable",
-        "version": "v1.4.0",
-        "type": "drupal-library",
-        "dist": {
-          "url": "https://github.com/RubaXa/Sortable/archive/1.4.0.zip",
-          "type": "zip"
+    "require": {
+        "cweagans/composer-patches": "^1.5.0",
+        "composer/installers": "^1.0",
+        "drupal/admin_toolbar": "^1.18",
+        "drupal/core": "^8.3",
+        "drupal/paragraphs": "^1.0",
+        "drupal/pathauto": "^1.0-beta2",
+        "drupal/migrate_plus": "^3.0-beta1",
+        "drupal/migrate_source_csv": "^2.0",
+        "drupal/migrate_tools": "^3.0-beta1",
+        "drupal/purge": "^3.0@beta",
+        "drupal/purge_purger_http": "^1.0@beta",
+        "drupal/search_api": "1.x-dev#1a29559f9f09b181e5da4b9becf36ae9a41b9440",
+        "drupal/search_api_solr": "1.x-dev#7cb30ed5ecbe76171438c668abf1d3e9045cfa81",
+        "drupal/search_api_autocomplete": "1.0.0-alpha1",
+        "drupal/contact_ajax": "^1.4@beta",
+        "drupal/contact_block": "^1.3",
+        "drupal/honeypot": "^1.23",
+        "drupal/google_analytics": "2.x-dev#8a3bd1b63764e88ebe1b96fb362a8aec54d912e9",
+        "drupal-composer/drupal-scaffold": "^2.2",
+        "drupal/samlauth": "2.0-alpha0",
+        "drupal/google_analytics_reports": "3.0-beta1",
+        "drupal/video_embed_field": "^1.4",
+        "drupal/noreqnewpass": "1.x-dev#f0d42e42fbac538dcf47d3ff8f5b14000fa19ffd",
+        "drupal/block_access": "dev-8.x-1.x#1cd59ba6856c897afae2551feaa8e6b7f312489c",
+        "drupal/content_lock": "^1.0@alpha",
+        "drupal/flag": "4.0.0-alpha1",
+        "RubaXa/Sortable": "1.4.0",
+        "drupal/facets": "^1.0@alpha",
+        "drupal/config_ignore": "^1.3",
+        "drupal/draggableviews": "^1.0",
+        "drupal/restui": "^1.14",
+        "drupal/edit_own_user_account_permission": "1.x-dev#68b5906f02df22506faf2a8599f063ba76552a78",
+        "UH-StudentServices/video_embed_unitube": "^1.0-alpha1"
+    },
+    "repositories": {
+        "0": {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        "1": {
+            "type": "vcs",
+            "url": "https://github.com/larowlan/block_access"
+        },
+        "2": {
+            "type": "package",
+            "package": {
+                "name": "RubaXa/Sortable",
+                "version": "v1.4.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/RubaXa/Sortable/archive/1.4.0.zip",
+                    "type": "zip"
+                }
+            }
+        },
+        "video_embed_unitube": {
+            "type": "vcs",
+            "url": "https://github.com/UH-StudentServices/video_embed_unitube"
         }
-      }
-    }
-  ],
-  "scripts": {
-    "post-install-cmd": [
-      "@composer drupal-scaffold"
-    ],
-    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
-  },
-  "extra": {
-    "installer-paths": {
-      "web/core": ["type:drupal-core"],
-      "web/libraries/{$name}": ["type:drupal-library"],
-      "web/profiles/{$name}": ["type:drupal-profile"],
-      "web/modules/contrib/{$name}": ["type:drupal-module"],
-      "web/themes/contrib/{$name}": ["type:drupal-theme"],
-      "web/drush/commands/{$name}": ["type:drupal-drush"]
     },
-    "enable-patching": true,
-    "patches": {
-      "drupal/samlauth": {
-        "2816997-7": "https://www.drupal.org/files/issues/samlauth-allow_custom_cert_folder-2816997-7.patch",
-        "2817005-11": "https://www.drupal.org/files/issues/samlauth-add_event_to_map_attributes_to_user-2817005-11.patch",
-        "2860473-1": "https://www.drupal.org/files/issues/2860473-1.patch"
-      },
-      "drupal/google_analytics_reports": {
-        "2795115-6-and-2860399-1": "patches/google_analytics_reports.patch",
-        "2850463-2": "https://www.drupal.org/files/issues/error_when_saving-2850463-2.patch"
-      },
-      "drupal/flag" : {
-        "2846111-4": "https://www.drupal.org/files/issues/broken_ajax_link_views-2846111-4.patch"
-      }
+    "scripts": {
+        "post-install-cmd": [
+            "@composer drupal-scaffold"
+        ],
+        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
+    },
+    "extra": {
+        "installer-paths": {
+            "web/core": [
+                "type:drupal-core"
+            ],
+            "web/libraries/{$name}": [
+                "type:drupal-library"
+            ],
+            "web/profiles/{$name}": [
+                "type:drupal-profile"
+            ],
+            "web/modules/contrib/{$name}": [
+                "type:drupal-module"
+            ],
+            "web/themes/contrib/{$name}": [
+                "type:drupal-theme"
+            ],
+            "web/drush/commands/{$name}": [
+                "type:drupal-drush"
+            ]
+        },
+        "enable-patching": true,
+        "patches": {
+            "drupal/samlauth": {
+                "2816997-7": "https://www.drupal.org/files/issues/samlauth-allow_custom_cert_folder-2816997-7.patch",
+                "2817005-11": "https://www.drupal.org/files/issues/samlauth-add_event_to_map_attributes_to_user-2817005-11.patch",
+                "2860473-1": "https://www.drupal.org/files/issues/2860473-1.patch"
+            },
+            "drupal/google_analytics_reports": {
+                "2795115-6-and-2860399-1": "patches/google_analytics_reports.patch",
+                "2850463-2": "https://www.drupal.org/files/issues/error_when_saving-2850463-2.patch"
+            },
+            "drupal/flag": {
+                "2846111-4": "https://www.drupal.org/files/issues/broken_ajax_link_views-2846111-4.patch"
+            }
+        }
     }
-  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e53c544b6ea2aef8a6457e3ecd09c9aa",
+    "content-hash": "cb898c7a8b8b0bb5012a77c77621e7eb",
     "packages": [
         {
             "name": "RubaXa/Sortable",
@@ -16,6 +16,34 @@
                 "shasum": null
             },
             "type": "drupal-library"
+        },
+        {
+            "name": "UH-StudentServices/video_embed_unitube",
+            "version": "1.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/UH-StudentServices/video_embed_unitube.git",
+                "reference": "f87cd650f3bbc2e07a489199a6ba3b5e7f1f25c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/UH-StudentServices/video_embed_unitube/zipball/f87cd650f3bbc2e07a489199a6ba3b5e7f1f25c6",
+                "reference": "f87cd650f3bbc2e07a489199a6ba3b5e7f1f25c6",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/video_embed_field": "~1.5"
+            },
+            "type": "drupal-module",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "description": "Use UniTube video URLs while embedding your video with Video Embed Field module.",
+            "support": {
+                "source": "https://github.com/UH-StudentServices/video_embed_unitube/tree/1.0-alpha1",
+                "issues": "https://github.com/UH-StudentServices/video_embed_unitube/issues"
+            },
+            "time": "2017-08-08T13:21:54+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -2620,17 +2648,17 @@
         },
         {
             "name": "drupal/video_embed_field",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/video_embed_field",
-                "reference": "8.x-1.4"
+                "reference": "8.x-1.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/video_embed_field-8.x-1.4.zip",
-                "reference": "8.x-1.4",
-                "shasum": "7bf93a52e2e8d639b4dbefd65f0ee2b170d73f43"
+                "url": "https://ftp.drupal.org/files/projects/video_embed_field-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "f54d470ef7f863604e51e6ae98cd40ef25de5f79"
             },
             "require": {
                 "drupal/core": "*"
@@ -5558,7 +5586,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://ftp.drupal.org/files/projects/devel-8.x-1.0-rc1.zip",
-                "reference": null,
+                "reference": "8.x-1.0-rc1",
                 "shasum": "04a01f50d508eca70e065b7eba38cd6c83a436c0"
             },
             "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb898c7a8b8b0bb5012a77c77621e7eb",
+    "content-hash": "282848da9ecdb20f94e110620401f82d",
     "packages": [
         {
             "name": "RubaXa/Sortable",
@@ -765,7 +765,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.18",
-                    "datestamp": "1491487683"
+                    "datestamp": "1480614184"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -824,7 +824,7 @@
                 "source": "https://github.com/larowlan/block_access/tree/8.x-1.x",
                 "issues": "https://github.com/larowlan/block_access/issues"
             },
-            "time": "2017-01-12 08:55:41"
+            "time": "2017-01-12T08:55:41+00:00"
         },
         {
             "name": "drupal/config_ignore",
@@ -850,7 +850,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1490346183"
+                    "datestamp": "1487336284"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -944,7 +944,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1493036943"
+                    "datestamp": "1481007784"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1223,7 +1223,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0-alpha27",
-                    "datestamp": "1490677984"
+                    "datestamp": "1471723439"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1381,7 +1381,50 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/edit_own_user_account_permission"
             },
-            "time": "2017-05-06 20:17:50"
+            "time": "2017-05-06T20:17:50+00:00"
+        },
+        {
+            "name": "drupal/editor_file",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/editor_file",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/editor_file-8.x-1.2.zip",
+                "reference": null,
+                "shasum": "e1fdfec93f98c219a6adea133033f1d21b8c53de"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1478115534"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "DuaelFr",
+                    "homepage": "https://www.drupal.org/user/931394"
+                }
+            ],
+            "description": "Allow users to link uploaded files in the text Editor.",
+            "homepage": "https://www.drupal.org/project/editor_file",
+            "support": {
+                "source": "http://cgit.drupalcode.org/editor_file"
+            }
         },
         {
             "name": "drupal/entity_reference_revisions",
@@ -1410,7 +1453,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1495814284"
+                    "datestamp": "1485790085"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1461,7 +1504,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha4",
-                    "datestamp": "1490096883"
+                    "datestamp": "1474662540"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1515,7 +1558,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1490003883"
+                    "datestamp": "1482263583"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1534,6 +1577,26 @@
                 {
                     "name": "borisson_",
                     "homepage": "https://www.drupal.org/user/2393360"
+                },
+                {
+                    "name": "drunken monkey",
+                    "homepage": "https://www.drupal.org/user/205582"
+                },
+                {
+                    "name": "jurcello",
+                    "homepage": "https://www.drupal.org/user/774070"
+                },
+                {
+                    "name": "marthinal",
+                    "homepage": "https://www.drupal.org/user/387593"
+                },
+                {
+                    "name": "mr.baileys",
+                    "homepage": "https://www.drupal.org/user/383424"
+                },
+                {
+                    "name": "swentel",
+                    "homepage": "https://www.drupal.org/user/107403"
                 }
             ],
             "description": "The Facet module allows site builders to easily create and manage faceted search interfaces.",
@@ -1568,7 +1631,7 @@
                 },
                 "drupal": {
                     "version": "8.x-4.0-alpha1",
-                    "datestamp": "1494517385"
+                    "datestamp": "1483948886"
                 },
                 "patches_applied": {
                     "2846111-4": "https://www.drupal.org/files/issues/broken_ajax_link_views-2846111-4.patch"
@@ -1639,8 +1702,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.1+24-dev",
-                    "datestamp": "1491162482"
+                    "version": "8.x-2.1+7-dev",
+                    "datestamp": "1475613839"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1663,7 +1726,7 @@
                 "source": "http://git.drupal.org/project/google_analytics.git",
                 "issues": "https://www.drupal.org/project/issues/google_analytics"
             },
-            "time": "2016-09-03 15:20:18"
+            "time": "2016-09-03T15:20:18+00:00"
         },
         {
             "name": "drupal/google_analytics_reports",
@@ -1810,7 +1873,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.23",
-                    "datestamp": "1490277183"
+                    "datestamp": "1457671745"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1869,7 +1932,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0-beta1",
-                    "datestamp": "1494450485"
+                    "datestamp": "1476307739"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1881,10 +1944,6 @@
                     "name": "Mike Ryan",
                     "homepage": "https://www.drupal.org/u/mikeryan",
                     "role": "Maintainer"
-                },
-                {
-                    "name": "mikeryan",
-                    "homepage": "https://www.drupal.org/user/4420"
                 }
             ],
             "description": "Enhancements to core migration support.",
@@ -1974,7 +2033,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0-beta1",
-                    "datestamp": "1494450485"
+                    "datestamp": "1476313439"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2045,7 +2104,7 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/noreqnewpass"
             },
-            "time": "2016-10-07 15:16:43"
+            "time": "2016-10-07T15:16:43+00:00"
         },
         {
             "name": "drupal/paragraphs",
@@ -2141,7 +2200,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc1",
-                    "datestamp": "1493468044"
+                    "datestamp": "1485702484"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2336,7 +2395,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.14",
-                    "datestamp": "1496919842"
+                    "datestamp": "1493396643"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2445,8 +2504,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.2+1-dev",
-                    "datestamp": "1498403042"
+                    "version": "8.x-1.0-beta4+32-dev",
+                    "datestamp": "1488030783"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2474,7 +2533,7 @@
                 "issues": "https://www.drupal.org/project/issues/search_api",
                 "irc": "irc://irc.freenode.org/drupal-search-api"
             },
-            "time": "2017-03-13 17:16:05"
+            "time": "2017-03-13T17:16:05+00:00"
         },
         {
             "name": "drupal/search_api_autocomplete",
@@ -2501,7 +2560,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1495529883"
+                    "datestamp": "1478684640"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2580,7 +2639,7 @@
                 "issues": "https://www.drupal.org/project/issues/search_api_solr",
                 "irc": "irc://irc.freenode.org/drupal-search-api"
             },
-            "time": "2017-01-30 17:52:46"
+            "time": "2017-01-30T17:52:46+00:00"
         },
         {
             "name": "drupal/token",
@@ -2606,7 +2665,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc1",
-                    "datestamp": "1493466843"
+                    "datestamp": "1483290542"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2657,7 +2716,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://ftp.drupal.org/files/projects/video_embed_field-8.x-1.5.zip",
-                "reference": "8.x-1.5",
+                "reference": null,
                 "shasum": "f54d470ef7f863604e51e6ae98cd40ef25de5f79"
             },
             "require": {
@@ -5602,7 +5661,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc1",
-                    "datestamp": "1492989244"
+                    "datestamp": "1484837884"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5637,12 +5696,24 @@
                     "homepage": "https://www.drupal.org/node/3236/committers"
                 },
                 {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "pcambra",
+                    "homepage": "https://www.drupal.org/user/122101"
+                },
+                {
                     "name": "salvis",
                     "homepage": "https://www.drupal.org/user/82964"
                 },
                 {
                     "name": "willzyx",
                     "homepage": "https://www.drupal.org/user/1043862"
+                },
+                {
+                    "name": "yched",
+                    "homepage": "https://www.drupal.org/user/39567"
                 }
             ],
             "description": "Various blocks, pages, and functions for developers.",
@@ -5970,7 +6041,7 @@
                 {
                     "name": "Anthon Pang",
                     "email": "apang@softwaredevelopment.ca",
-                    "role": "Fork maintainer"
+                    "role": "Fork Maintainer"
                 }
             ],
             "description": "PHP WebDriver for Selenium 2",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -90,6 +90,7 @@ module:
   uhsg_user_sync: 0
   user: 0
   video_embed_field: 0
+  video_embed_unitube: 0
   views_ui: 0
   menu_link_content: 1
   pathauto: 1

--- a/config/sync/filter.format.filtered_html.yml
+++ b/config/sync/filter.format.filtered_html.yml
@@ -28,14 +28,14 @@ filters:
     status: true
     weight: 0
     settings: {  }
-  filter_align:
-    id: filter_align
+  filter_caption:
+    id: filter_caption
     provider: filter
     status: true
     weight: 0
     settings: {  }
-  filter_caption:
-    id: filter_caption
+  filter_align:
+    id: filter_align
     provider: filter
     status: true
     weight: 0


### PR DESCRIPTION
Alongside, while adding the repository via command. Some extra reformatting was taken place.
Also, video_embed_field needed to be updated to v1.5.

If you have major `composer.lock` conflict, check their head and re-type these commands to get same results as in this branch:
```
$ composer update video_embed_field
$ composer config repositories.video_embed_unitube vcs https://github.com/UH-StudentServices/video_embed_unitube
$ composer require composer require UH-StudentServices/video_embed_unitube:^v1.0-alpha1
```