### PR TITLE
HUB-234: Atom/RSS feed for news

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release date: ??.??.2017
 * Added possibility to attach inline files to body fields (HUB-226)
 * Changed feedback recipient email address (HUB-228)
 * Cleaned up transitional degree programme handling (HUB-220)
+* Added Atom+RSS news feed that support degree programme targeting (HUB-234)
 
 ## 1.5
 Release date: 27.06.2017

--- a/config/sync/filter.format.filtered_html.yml
+++ b/config/sync/filter.format.filtered_html.yml
@@ -28,14 +28,14 @@ filters:
     status: true
     weight: 0
     settings: {  }
-  filter_caption:
-    id: filter_caption
+  filter_align:
+    id: filter_align
     provider: filter
     status: true
     weight: 0
     settings: {  }
-  filter_align:
-    id: filter_align
+  filter_caption:
+    id: filter_caption
     provider: filter
     status: true
     weight: 0

--- a/modules/uhsg_active_degree_programme/uhsg_active_degree_programme.services.yml
+++ b/modules/uhsg_active_degree_programme/uhsg_active_degree_programme.services.yml
@@ -6,4 +6,4 @@ services:
       - { name: cache.context }
   uhsg_active_degree_programme.active_degree_programme:
     class: Drupal\uhsg_active_degree_programme\ActiveDegreeProgrammeService
-    arguments: ['@config.factory', '@request_stack', '@entity.repository', '@current_user', '@flag']
+    arguments: ['@config.factory', '@request_stack', '@entity.repository', '@entity_type.manager', '@current_user', '@flag']

--- a/modules/uhsg_news/src/Controller/NewsFeedController.php
+++ b/modules/uhsg_news/src/Controller/NewsFeedController.php
@@ -92,6 +92,7 @@ class NewsFeedController extends ControllerBase {
         if ($node->get('body')->count() > 0) {
           $entry->setDescription(text_summary($node->get('body')
             ->first()
+            ->get('value')
             ->getString()));
         }
         $feed->addEntry($entry);

--- a/modules/uhsg_news/src/Controller/NewsFeedController.php
+++ b/modules/uhsg_news/src/Controller/NewsFeedController.php
@@ -78,19 +78,24 @@ class NewsFeedController extends ControllerBase {
     /** @var \Drupal\node\Entity\Node $node */
     $modified = array();
     foreach ($nodes as $node) {
-      // Setup item
-      $url = $node->url('canonical', ['absolute' => TRUE]);
-      $modified[] = $node->getChangedTime();
-      $entry = $feed->createEntry();
-      $entry->setTitle($node->label());
-      $entry->setLink($url);
-      $entry->setId($url);
-      $entry->setDateCreated(new \DateTime('@' . $node->getCreatedTime()));
-      $entry->setDateModified(new \DateTime('@' . $node->getChangedTime()));
-      if ($node->get('body')->count() > 0) {
-        $entry->setDescription(text_summary($node->get('body')->first()->getString()));
+      // List nodes that we have access to.
+      if ($node->access()) {
+        // Setup item
+        $url = $node->url('canonical', ['absolute' => TRUE]);
+        $modified[] = $node->getChangedTime();
+        $entry = $feed->createEntry();
+        $entry->setTitle($node->label());
+        $entry->setLink($url);
+        $entry->setId($url);
+        $entry->setDateCreated(new \DateTime('@' . $node->getCreatedTime()));
+        $entry->setDateModified(new \DateTime('@' . $node->getChangedTime()));
+        if ($node->get('body')->count() > 0) {
+          $entry->setDescription(text_summary($node->get('body')
+            ->first()
+            ->getString()));
+        }
+        $feed->addEntry($entry);
       }
-      $feed->addEntry($entry);
     }
 
     if (empty($modified)) {

--- a/modules/uhsg_news/src/Controller/NewsFeedController.php
+++ b/modules/uhsg_news/src/Controller/NewsFeedController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\uhsg_news\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\uhsg_news\TargetedNewsService;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zend\Feed\Writer\Feed;
+
+class NewsFeedController extends ControllerBase {
+
+  /**
+   * @var \Drupal\uhsg_news\TargetedNewsService
+   */
+  protected $targetedNewsService;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * NewsFeedController constructor.
+   *
+   * @param TargetedNewsService $targetedNewsService
+   * @param EntityTypeManagerInterface $entityTypeManager
+   */
+  public function __construct(TargetedNewsService $targetedNewsService, EntityTypeManagerInterface $entityTypeManager) {
+    $this->targetedNewsService = $targetedNewsService;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('uhsg_news.targeted_news'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Returns an RSS feed response using targeted news service.
+   *
+   * @return Response
+   */
+  public function feed() {
+    $degree_programme = NULL;
+    $headers = [
+      'Content-Type' => 'application/rss+xml'
+    ];
+    // Get the nodes that we build RSS feed from
+    $nids = $this->targetedNewsService->getTargetedNewsNids(6);
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    return new Response($this->generateFeed($nodes), 200, $headers);
+  }
+
+  protected function generateFeed($nodes) {
+
+    // Create the feed
+    $feed = new Feed();
+    $feed->setTitle($this->t('News feed')->render());
+    $feed->setDescription($this->t('Latest relevant news from Guide.')->render());
+
+    // Generate URL to news (HTML page)
+    $view = Views::getView('news');
+    $view->setDisplay('page_1');
+    $url = $view->getUrl();
+    $url->setAbsolute(TRUE);
+    $feed->setLink(\Drupal::urlGenerator()->generateFromRoute($url->getRouteName(), $url->getRouteParameters(), $url->getOptions()));
+
+    // Add items
+    /** @var \Drupal\node\Entity\Node $node */
+    $modified = array();
+    foreach ($nodes as $node) {
+      // Setup item
+      $url = $node->url('canonical', ['absolute' => TRUE]);
+      $modified[] = $node->getChangedTime();
+      $entry = $feed->createEntry();
+      $entry->setTitle($node->label());
+      $entry->setLink($url);
+      $entry->setId($url);
+      $entry->setDateCreated(new \DateTime('@' . $node->getCreatedTime()));
+      $entry->setDateModified(new \DateTime('@' . $node->getChangedTime()));
+      if ($node->get('body')->count() > 0) {
+        $entry->setDescription(text_summary($node->get('body')->first()->getString()));
+      }
+      $feed->addEntry($entry);
+    }
+
+    if (empty($modified)) {
+      $modified[] = REQUEST_TIME;
+    }
+    $feed->setDateModified(new \DateTime('@' . max($modified)));
+    $feed->setFeedLink(Url::fromRoute('<current>', [], ['absolute' => TRUE])->toString(), 'atom');
+    $feed->setGenerator('Guide');
+
+    // Return the feed formatted as ATOM feed
+    return $feed->export('atom');
+  }
+}

--- a/modules/uhsg_news/src/Controller/NewsFeedController.php
+++ b/modules/uhsg_news/src/Controller/NewsFeedController.php
@@ -81,16 +81,17 @@ class NewsFeedController extends ControllerBase {
       // List nodes that we have access to.
       if ($node->access()) {
         // Setup item
-        $url = $node->url('canonical', ['absolute' => TRUE]);
-        $modified[] = $node->getChangedTime();
+        $translation = $node->getTranslation($this->languageManager()->getCurrentLanguage()->getId());
+        $url = $translation->url('canonical', ['absolute' => TRUE]);
+        $modified[] = $translation->getChangedTime();
         $entry = $feed->createEntry();
-        $entry->setTitle($node->label());
+        $entry->setTitle($translation->label());
         $entry->setLink($url);
         $entry->setId($url);
-        $entry->setDateCreated(new \DateTime('@' . $node->getCreatedTime()));
-        $entry->setDateModified(new \DateTime('@' . $node->getChangedTime()));
-        if ($node->get('body')->count() > 0) {
-          $entry->setDescription(text_summary($node->get('body')
+        $entry->setDateCreated(new \DateTime('@' . $translation->getCreatedTime()));
+        $entry->setDateModified(new \DateTime('@' . $translation->getChangedTime()));
+        if ($translation->get('body')->count() > 0) {
+          $entry->setDescription(text_summary($translation->get('body')
             ->first()
             ->get('value')
             ->getString()));

--- a/modules/uhsg_news/src/Plugin/Block/NewsPerDegreeProgramme.php
+++ b/modules/uhsg_news/src/Plugin/Block/NewsPerDegreeProgramme.php
@@ -23,22 +23,6 @@ class NewsPerDegreeProgramme extends BlockBase {
    */
   public function build() {
     $renderableArray = [];
-    $lang = \Drupal::languageManager()->getCurrentLanguage()->getId();
-
-    $query = \Drupal::entityQuery('node')
-      ->condition('status', 1)
-      ->condition('langcode', $lang)
-      ->condition('type', 'news')
-      ->sort('created', 'DESC')
-      ->range(0, 3);
-    $group = $query->orConditionGroup()
-      ->condition('field_news_degree_programme', NULL, 'IS NULL');
-
-    // if on term page, add tid to condition group
-    $tid = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getId();
-    if ($tid) {
-      $group->condition('field_news_degree_programme', $tid);
-    }
 
     // get link to news view
     $view = Views::getView('news');
@@ -57,7 +41,8 @@ class NewsPerDegreeProgramme extends BlockBase {
     ]);
     $link = Link::fromTextAndUrl($this->t('More current topics'), $url)->toString();
 
-    $nids = $query->condition($group)->execute();
+    $targeted_news = \Drupal::service('uhsg_news.targeted_news');
+    $nids = $targeted_news->getTargetedNewsNids();
 
     if ($nids) {
       $nodes = Node::loadMultiple($nids);

--- a/modules/uhsg_news/src/TargetedNewsService.php
+++ b/modules/uhsg_news/src/TargetedNewsService.php
@@ -60,12 +60,12 @@ class TargetedNewsService {
       ->sort('created', 'DESC')
       ->range(0, $limit);
     $group = $query->orConditionGroup()
-      ->condition($referenceField, NULL, 'IS NULL');
+      ->condition($this->referenceField, NULL, 'IS NULL');
 
     // If active degree programme present, add tid to condition group
     $tid = $this->activeDegreeProgrammeService->getId();
     if ($tid) {
-      $group->condition($referenceField, $tid);
+      $group->condition($this->referenceField, $tid);
     }
 
     $nids = $query->condition($group)->execute();

--- a/modules/uhsg_news/src/TargetedNewsService.php
+++ b/modules/uhsg_news/src/TargetedNewsService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\uhsg_news;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\uhsg_active_degree_programme\ActiveDegreeProgrammeService;
+
+class TargetedNewsService {
+
+  /**
+   * For querying IDs of news.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * For getting active language and therefore correct language of values.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * For getting correct targeter.
+   *
+   * @var \Drupal\uhsg_active_degree_programme\ActiveDegreeProgrammeService
+   */
+  protected $activeDegreeProgrammeService;
+
+  protected $targetEntityType = 'node';
+  protected $targetBundle = 'news';
+  protected $referenceField = 'field_news_degree_programme';
+
+  /**
+   * @param EntityTypeManagerInterface $entityTypeManager
+   * @param LanguageManagerInterface $languageManager
+   * @param ActiveDegreeProgrammeService $activeDegreeProgrammeService
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, LanguageManagerInterface $languageManager, ActiveDegreeProgrammeService $activeDegreeProgrammeService) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->languageManager = $languageManager;
+    $this->activeDegreeProgrammeService = $activeDegreeProgrammeService;
+  }
+
+  /**
+   * Returns collection of Node IDs that is targeted for current request.
+   *
+   * @param int $limit
+   *   Number of maximum items to fetch.
+   *
+   * @return array
+   */
+  public function getTargetedNewsNids($limit = 3) {
+    $query = \Drupal::entityQuery($this->targetEntityType)
+      ->condition('status', NODE_PUBLISHED)
+      ->condition('langcode', $this->languageManager->getCurrentLanguage()->getId())
+      ->condition('type', $this->targetBundle)
+      ->sort('created', 'DESC')
+      ->range(0, $limit);
+    $group = $query->orConditionGroup()
+      ->condition($referenceField, NULL, 'IS NULL');
+
+    // If active degree programme present, add tid to condition group
+    $tid = $this->activeDegreeProgrammeService->getId();
+    if ($tid) {
+      $group->condition($referenceField, $tid);
+    }
+
+    $nids = $query->condition($group)->execute();
+    return !empty($nids) ? $nids : array();
+  }
+
+}

--- a/modules/uhsg_news/uhsg_news.info.yml
+++ b/modules/uhsg_news/uhsg_news.info.yml
@@ -1,6 +1,6 @@
 name: News
 type: module
-description: Provides a news block.
+description: Provides advanced properties for news like filtered listings and emailing.
 core: 8.x
 version: VERSION
 package: Student Guide

--- a/modules/uhsg_news/uhsg_news.info.yml
+++ b/modules/uhsg_news/uhsg_news.info.yml
@@ -4,3 +4,5 @@ description: Provides advanced properties for news like filtered listings and em
 core: 8.x
 version: VERSION
 package: Student Guide
+dependencies:
+  - uhsg_active_degree_programme

--- a/modules/uhsg_news/uhsg_news.module
+++ b/modules/uhsg_news/uhsg_news.module
@@ -16,7 +16,7 @@ function uhsg_news_help($route_name, RouteMatchInterface $route_match) {
     case 'help.page.uhsg_news':
       $output = '';
       $output .= '<h3>' . t('About') . '</h3>';
-      $output .= '<p>' . t('Provides a news block.') . '</p>';
+      $output .= '<p>' . t('Provides advanced properties for news like filtered listings and emailing.') . '</p>';
       return $output;
 
     default:

--- a/modules/uhsg_news/uhsg_news.routing.yml
+++ b/modules/uhsg_news/uhsg_news.routing.yml
@@ -1,0 +1,7 @@
+uhsg_news.rss:
+  path: '/news/feed.xml'
+  defaults:
+    _controller: '\Drupal\uhsg_news\Controller\NewsFeedController::feed'
+    _title: 'News Atom feed'
+  requirements:
+    _permission: 'access content'

--- a/modules/uhsg_news/uhsg_news.services.yml
+++ b/modules/uhsg_news/uhsg_news.services.yml
@@ -1,0 +1,4 @@
+services:
+  uhsg_news.targeted_news:
+    class: Drupal\uhsg_news\TargetedNewsService
+    arguments: ['@entity_type.manager', '@language_manager', '@uhsg_active_degree_programme.active_degree_programme']


### PR DESCRIPTION
* This feed is aware of active degree programme (cookies, headers or query parameter)
* Works centralized with same query as with news promotions at front page
* Active degree programme can be now set through query parameter with the code directly (`{URL}?degree_programme_code=KH57_001`)

Testing URL examples:
* https://local.guide.student.helsinki.fi/en/news/feed.xml?degree_programme_code=KH57_001
* https://local.guide.student.helsinki.fi/fi/news/feed.xml?degree_programme_code=KH57_001
* https://local.guide.student.helsinki.fi/sv/news/feed.xml?degree_programme_code=KH57_001
* https://local.guide.student.helsinki.fi/fi/news/feed.xml (just general news only)
* https://local.guide.student.helsinki.fi/fi/news/feed.xml?degree_programme=90 (if you would like to use term ids instead)