### PR TITLE
Feature/hub 237 second level main navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.12-dev
 Release date: ??.??.????
 
+* Support for second level main navigation (HUB-237)
 
 ## 1.11
 Release date: 20.11.2017

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8031,7 +8031,7 @@ input[type="submit"].button--reset + i {
     padding-top: 0;
     padding-bottom: 0;
   }
-  .main-menu li.is-lvl1 > a {
+  .main-menu li.is-lvl1 > a, .main-menu li.is-lvl1 span[data-drupal-link-system-path] {
     padding-top: 1.2em;
     padding-bottom: 1.2em;
   }
@@ -8048,6 +8048,23 @@ input[type="submit"].button--reset + i {
     width: 100%;
     border-left: 1px solid #D2D2D2;
   }
+  .main-menu li.is-lvl1 span[data-drupal-link-system-path] {
+    font-size: 0.9375rem;
+    font-weight: 700;
+    font-style: normal;
+    color: #0098d0;
+    display: block;
+    line-height: 1.25em;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+    text-decoration: none;
+    padding-right: 1em;
+    padding-left: 1.8em;
+  }
+}
+
+.main-menu li.is-lvl1 span[data-drupal-link-system-path] {
+  padding: 15px 20px 15px 60px;
 }
 
 @media (min-width: 48em) {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8028,13 +8028,17 @@ input[type="submit"].button--reset + i {
 
 @media (min-width: 48em) {
   .main-menu > ul.menu {
-    max-height: 55px;
     padding-top: 0;
     padding-bottom: 0;
   }
   .main-menu li.is-lvl1 > a {
     padding-top: 1.2em;
     padding-bottom: 1.2em;
+  }
+  .main-menu li.is-expandable {
+    -webkit-align-items: baseline;
+        -ms-flex-align: baseline;
+            align-items: baseline;
   }
 }
 

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8040,6 +8040,14 @@ input[type="submit"].button--reset + i {
         -ms-flex-align: baseline;
             align-items: baseline;
   }
+  .main-menu li.is-expandable nav {
+    position: fixed;
+    margin-top: 3.4em;
+    z-index: 200;
+    background: white;
+    width: 100%;
+    border-left: 1px solid #D2D2D2;
+  }
 }
 
 @media (min-width: 48em) {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8064,7 +8064,7 @@ input[type="submit"].button--reset + i {
 }
 
 .main-menu li.is-lvl1 span[data-drupal-link-system-path] {
-  padding: 15px 20px 15px 60px;
+  padding: 18px 20px 15px 60px;
 }
 
 @media (min-width: 48em) {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -463,45 +463,30 @@ th {
 }
 
 .icon-rotate-90:after {
-  -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
 .icon-rotate-180:after {
-  -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
 .icon-rotate-270:after {
-  -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 
-@-webkit-keyframes icon-spin {
-  from {
-    -webkit-transform: rotate(0deg);
-  }
-  to {
-    -webkit-transform: rotate(360deg);
-  }
-}
-
 @keyframes icon-spin {
   from {
-    -webkit-transform: rotate(0deg);
-            transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   to {
-    -webkit-transform: rotate(360deg);
-            transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 
 .icon-spin:after {
-  -webkit-animation: icon-spin 2s infinite linear;
   animation: icon-spin 2s infinite linear;
 }
 
@@ -1799,45 +1784,30 @@ th {
 }
 
 .icon-rotate-90:after {
-  -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
 .icon-rotate-180:after {
-  -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
 .icon-rotate-270:after {
-  -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 
-@-webkit-keyframes icon-spin {
-  from {
-    -webkit-transform: rotate(0deg);
-  }
-  to {
-    -webkit-transform: rotate(360deg);
-  }
-}
-
 @keyframes icon-spin {
   from {
-    -webkit-transform: rotate(0deg);
-            transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   to {
-    -webkit-transform: rotate(360deg);
-            transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 
 .icon-spin:after {
-  -webkit-animation: icon-spin 2s infinite linear;
   animation: icon-spin 2s infinite linear;
 }
 
@@ -3424,9 +3394,8 @@ input[type="checkbox"] {
 input[type="radio"] + label,
 input[type="checkbox"] + label {
   font-size: 0.875rem;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   cursor: pointer;
   display: block;
   font-weight: normal;
@@ -3437,9 +3406,8 @@ input[type="checkbox"] + label {
 
 input[type="radio"] + label:before,
 input[type="checkbox"] + label:before {
-  -webkit-transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
-          transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+      transform: translateY(-50%);
   position: absolute;
   top: 50%;
   position: absolute;
@@ -3718,16 +3686,14 @@ input.theme-transparent[type="submit"] a:hover, .theme-transparent.button--small
   -moz-osx-font-smoothing: grayscale;
   vertical-align: bottom;
   content: "";
-  -webkit-transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
-          transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+      transform: translateY(-50%);
   position: absolute;
   top: 50%;
   left: 1em;
   position: absolute;
-  -webkit-transform: translateY(-50%) rotate(270deg);
-      -ms-transform: translateY(-50%) rotate(270deg);
-          transform: translateY(-50%) rotate(270deg);
+  -ms-transform: translateY(-50%) rotate(270deg);
+      transform: translateY(-50%) rotate(270deg);
   transition-duration: 0.1s;
 }
 
@@ -3739,9 +3705,8 @@ input.theme-transparent[type="submit"] a:hover, .theme-transparent.button--small
 
 .is-active.accordion__title:before,
 .button--accordion.is-active:before {
-  -webkit-transform: translateY(-50%) rotate(90deg);
-      -ms-transform: translateY(-50%) rotate(90deg);
-          transform: translateY(-50%) rotate(90deg);
+  -ms-transform: translateY(-50%) rotate(90deg);
+      transform: translateY(-50%) rotate(90deg);
   color: #FFF;
 }
 
@@ -3770,18 +3735,15 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 
 .button--action-before:after,
 .button--action:after {
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   background-color: #0882B3;
   color: #FFF;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   height: 100%;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+      justify-content: center;
   position: absolute;
   right: 0;
   top: 0;
@@ -3799,10 +3761,8 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 .theme-transparent-alt.button--action-before,
 .button--action.theme-transparent,
 .button--action.theme-transparent-alt {
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-flex;
+  -ms-flex-align: center;
+      align-items: center;
   display: -ms-flexbox;
   display: flex;
   padding-left: 0;
@@ -3892,9 +3852,8 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
   margin: 0;
   position: absolute;
   text-align: left;
-  -webkit-transform: none;
-      -ms-transform: none;
-          transform: none;
+  -ms-transform: none;
+      transform: none;
 }
 
 /*
@@ -4012,15 +3971,12 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 */
 
 .button-group {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  -ms-flex-direction: row;
+      flex-direction: row;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   position: relative;
 }
 
@@ -4250,25 +4206,20 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
   margin: 0 auto;
   max-width: 75em;
   padding: 0 1em;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
 }
 
 @media (min-width: 48em) {
   .l-footer__subregion {
-    -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-            flex-direction: row;
-    -webkit-flex-wrap: wrap;
-        -ms-flex-wrap: wrap;
-            flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
   }
 }
 
@@ -4285,16 +4236,14 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 
 .l-footer__column.theme-sub {
   margin-bottom: 0;
-  -webkit-order: 3;
-      -ms-flex-order: 3;
-          order: 3;
+  -ms-flex-order: 3;
+      order: 3;
 }
 
 @media (min-width: 48em) {
   .l-footer__column.theme-sub {
-    -webkit-order: 0;
-        -ms-flex-order: 0;
-            order: 0;
+    -ms-flex-order: 0;
+        order: 0;
   }
 }
 
@@ -4398,12 +4347,10 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 }
 
 .l-top-bar__subregion {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  -ms-flex-direction: column;
+      flex-direction: column;
 }
 
 @media (min-width: 48em) {
@@ -4411,33 +4358,26 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
     margin: 0 auto;
     max-width: 75em;
     padding: 0 1em;
-    -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-            flex-direction: row;
-    -webkit-flex-wrap: wrap;
-        -ms-flex-wrap: wrap;
-            flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
   }
 }
 
 .l-top-bar__main {
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   background-color: #222;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+      flex: 1 1 auto;
   height: 70px;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
-  -webkit-order: 2;
-      -ms-flex-order: 2;
-          order: 2;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
+  -ms-flex-order: 2;
+      order: 2;
   padding-left: 15px;
   position: relative;
   z-index: 25;
@@ -4445,39 +4385,33 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 
 @media (min-width: 48em) {
   .l-top-bar__main {
-    -webkit-order: 1;
-        -ms-flex-order: 1;
-            order: 1;
+    -ms-flex-order: 1;
+        order: 1;
     padding-left: 0;
   }
 }
 
 .l-top-bar__sub {
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-flex;
+  -ms-flex-align: center;
+      align-items: center;
   display: -ms-flexbox;
   display: flex;
-  -webkit-order: 1;
-      -ms-flex-order: 1;
-          order: 1;
+  -ms-flex-order: 1;
+      order: 1;
   padding: 0 15px;
 }
 
 @media (min-width: 48em) {
   .l-top-bar__sub {
-    -webkit-order: 2;
-        -ms-flex-order: 2;
-            order: 2;
+    -ms-flex-order: 2;
+        order: 2;
     padding: 0;
   }
 }
 
 .l-top-bar__subleft {
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+      flex: 1 1 auto;
 }
 
 @media (min-width: 48em) {
@@ -4498,17 +4432,15 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 }
 
 .is-center-mobile {
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+      justify-content: center;
   text-align: center;
 }
 
 @media (min-width: 48em) {
   .is-center-mobile {
-    -webkit-justify-content: flex-start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
+    -ms-flex-pack: start;
+        justify-content: flex-start;
     text-align: left;
   }
 }
@@ -4582,91 +4514,43 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 }
 
 .is-slidein {
-  -webkit-animation-duration: 0.2s;
-          animation-duration: 0.2s;
-  -webkit-animation-fill-mode: forwards;
-          animation-fill-mode: forwards;
-  -webkit-animation-name: slideIn;
-          animation-name: slideIn;
-}
-
-@-webkit-keyframes slideIn {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateY(-50px);
-            transform: translateY(-50px);
-  }
-  100% {
-    opacity: 1;
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
-  }
+  animation-duration: 0.2s;
+  animation-fill-mode: forwards;
+  animation-name: slideIn;
 }
 
 @keyframes slideIn {
   0% {
     opacity: 0;
-    -webkit-transform: translateY(-50px);
-            transform: translateY(-50px);
+    transform: translateY(-50px);
   }
   100% {
     opacity: 1;
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
+    transform: translateX(0);
   }
 }
 
 .is-slideout {
-  -webkit-animation-duration: 0.2s;
-          animation-duration: 0.2s;
-  -webkit-animation-fill-mode: forwards;
-          animation-fill-mode: forwards;
-  -webkit-animation-name: slideOut;
-          animation-name: slideOut;
-}
-
-@-webkit-keyframes slideOut {
-  0% {
-    opacity: 1;
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
-  }
-  100% {
-    opacity: 0;
-    -webkit-transform: translateY(-50px);
-            transform: translateY(-50px);
-  }
+  animation-duration: 0.2s;
+  animation-fill-mode: forwards;
+  animation-name: slideOut;
 }
 
 @keyframes slideOut {
   0% {
     opacity: 1;
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
+    transform: translateX(0);
   }
   100% {
     opacity: 0;
-    -webkit-transform: translateY(-50px);
-            transform: translateY(-50px);
+    transform: translateY(-50px);
   }
 }
 
 .is-fadein {
-  -webkit-animation-duration: 0.2s;
-          animation-duration: 0.2s;
-  -webkit-animation-fill-mode: forwards;
-          animation-fill-mode: forwards;
-  -webkit-animation-name: fadeIn;
-          animation-name: fadeIn;
-}
-
-@-webkit-keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
+  animation-duration: 0.2s;
+  animation-fill-mode: forwards;
+  animation-name: fadeIn;
 }
 
 @keyframes fadeIn {
@@ -4692,15 +4576,12 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 
 .box-story--liftup, .box-story--constrained,
 .box-story {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex: 1 1 auto;
+      flex: 1 1 auto;
   position: relative;
   transition-duration: 0.1s;
   transition-property: background-color;
@@ -4884,7 +4765,6 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
   .theme-black.box-story--liftup, .theme-black.box-story--constrained,
   .box-story.theme-black {
     background: #000;
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
   }
@@ -5070,14 +4950,12 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 }
 
 .box-story__title {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   transition-property: color;
   transition-duration: 0.1s;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   overflow: hidden;
 }
 
@@ -5100,9 +4978,8 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 
 .box-story__link-wrapper {
   display: block;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  -ms-flex-positive: 1;
+      flex-grow: 1;
 }
 
 .box-story__link {
@@ -5475,9 +5352,7 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 @media (min-width: 48em) {
   
   .index {
-    -webkit-columns: 2;
-       -moz-columns: 2;
-            columns: 2;
+    columns: 2;
   }
 }
 
@@ -5492,9 +5367,7 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
 
 @media (min-width: 48em) {
   .index__label {
-    -webkit-column-span: all;
-       -moz-column-span: all;
-            column-span: all;
+    column-span: all;
   }
 }
 
@@ -5761,29 +5634,25 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
  description: Links compontent is used in the top bar.
 */
 .links {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  -ms-flex-direction: row;
+      flex-direction: row;
   position: relative;
 }
 
 @media (min-width: 48em) {
   .links {
-    -webkit-flex-direction: column;
-        -ms-flex-direction: column;
-            flex-direction: column;
+    -ms-flex-direction: column;
+        flex-direction: column;
     text-align: right;
   }
 }
 
 @media (min-width: 75em) {
   .links {
-    -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-            flex-direction: row;
+    -ms-flex-direction: row;
+        flex-direction: row;
   }
 }
 
@@ -5861,24 +5730,20 @@ span.links__link.theme-language {
 }
 
 .main-menu li {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-flow: column wrap;
-      -ms-flex-flow: column wrap;
-          flex-flow: column wrap;
+  -ms-flex-flow: column wrap;
+      flex-flow: column wrap;
   list-style: none;
   position: relative;
 }
 
 @media (min-width: 48em) {
   .main-menu li {
-    -webkit-align-items: center;
-        -ms-flex-align: center;
-            align-items: center;
-    -webkit-flex-flow: row wrap;
-        -ms-flex-flow: row wrap;
-            flex-flow: row wrap;
+    -ms-flex-align: center;
+        align-items: center;
+    -ms-flex-flow: row wrap;
+        flex-flow: row wrap;
   }
 }
 
@@ -5908,12 +5773,10 @@ span.links__link.theme-language {
     max-width: 75em;
     padding: 0 1em;
     border: none;
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    -webkit-flex-flow: row wrap;
-        -ms-flex-flow: row wrap;
-            flex-flow: row wrap;
+    -ms-flex-flow: row wrap;
+        flex-flow: row wrap;
     height: 100%;
     padding: 0.6em 2em 0.6em 2em;
     position: relative;
@@ -6008,8 +5871,7 @@ span.links__link.theme-language {
     font-size: 1rem;
     font-weight: 300;
     font-style: normal;
-    -webkit-transform: translate3d(0, 0, 0);
-            transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
     transition: opacity 0.2s ease;
   }
 }
@@ -6049,7 +5911,6 @@ span.links__link.theme-language {
   position: relative;
   top: 10px;
   transition-duration: 0.2s;
-  transition-property: color, border-color, -webkit-transform;
   transition-property: color, border-color, transform;
   width: 2em;
 }
@@ -6060,19 +5921,15 @@ span.links__link.theme-language {
 
 @media (min-width: 48em) {
   .main-menu__expand {
-    -webkit-align-items: center;
-        -ms-flex-align: center;
-            align-items: center;
-    display: -webkit-flex;
+    -ms-flex-align: center;
+        align-items: center;
     display: -ms-flexbox;
     display: flex;
     height: 1.2em;
-    -webkit-justify-content: center;
-        -ms-flex-pack: center;
-            justify-content: center;
-    -webkit-order: 2;
-        -ms-flex-order: 2;
-            order: 2;
+    -ms-flex-pack: center;
+        justify-content: center;
+    -ms-flex-order: 2;
+        order: 2;
     position: static;
     width: 1.2em;
   }
@@ -6088,8 +5945,7 @@ span.links__link.theme-language {
 
 .is-open > .main-menu__expand:before {
   color: #0098d0;
-  -webkit-transform: rotate3d(1, 0, 0, 180deg);
-          transform: rotate3d(1, 0, 0, 180deg);
+  transform: rotate3d(1, 0, 0, 180deg);
 }
 
 .is-open > .main-menu__expand:hover:before {
@@ -6228,18 +6084,15 @@ span.links__link.theme-language {
   font-weight: 600;
   font-style: normal;
   font-size: 1.25rem;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   color: #0098d0;
   cursor: pointer;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   height: 2em;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+      justify-content: center;
   margin: 0;
   position: absolute;
   right: 10px;
@@ -6637,10 +6490,8 @@ span.links__link.theme-language {
 }
 
 .logo-block {
-  -webkit-align-items: flex-start;
-      -ms-flex-align: start;
-          align-items: flex-start;
-  display: -webkit-flex;
+  -ms-flex-align: start;
+      align-items: flex-start;
   display: -ms-flexbox;
   display: flex;
 }
@@ -6702,10 +6553,8 @@ span.links__link.theme-language {
 }
 
 .logo {
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-flex;
+  -ms-flex-align: center;
+      align-items: center;
   display: -ms-flexbox;
   display: flex;
 }
@@ -6750,22 +6599,17 @@ span.links__link.theme-language {
 
 ul.pager {
   font-size: 0.9375rem;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   color: #FFF;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-direction: row;
+      flex-direction: row;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -ms-flex-pack: center;
+      justify-content: center;
   margin: 30px 0;
 }
 
@@ -7308,12 +7152,10 @@ ul.pager > li.pager__page a {
 
 @media (min-width: 48em) {
   .grid-container {
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    -webkit-flex-flow: row wrap;
-        -ms-flex-flow: row wrap;
-            flex-flow: row wrap;
+    -ms-flex-flow: row wrap;
+        flex-flow: row wrap;
     margin: 0 -1em;
   }
   .grid-container > * {
@@ -7326,7 +7168,6 @@ ul.pager > li.pager__page a {
   padding-bottom: 2em;
   margin-left: auto;
   margin-right: auto;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   overflow: hidden;
@@ -7334,9 +7175,8 @@ ul.pager > li.pager__page a {
 
 .grid-item > article {
   display: block;
-  -webkit-flex-basis: 100%;
-      -ms-flex-preferred-size: 100%;
-          flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
 }
 
 @media (min-width: 48em) {
@@ -7407,29 +7247,24 @@ ul.pager > li.pager__page a {
 
 @media (min-width: 48em) {
   .col-container {
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
   }
   .col-right {
-    -webkit-flex-basis: 33.33333%;
-        -ms-flex-preferred-size: 33.33333%;
-            flex-basis: 33.33333%;
+    -ms-flex-preferred-size: 33.33333%;
+        flex-basis: 33.33333%;
     margin-left: 4em;
   }
   .col-left {
-    -webkit-flex-basis: 33.33333%;
-        -ms-flex-preferred-size: 33.33333%;
-            flex-basis: 33.33333%;
+    -ms-flex-preferred-size: 33.33333%;
+        flex-basis: 33.33333%;
     margin-right: 4em;
   }
   .col-main {
-    -webkit-flex-basis: 66.66667%;
-        -ms-flex-preferred-size: 66.66667%;
-            flex-basis: 66.66667%;
-    -webkit-flex-grow: 2;
-        -ms-flex-positive: 2;
-            flex-grow: 2;
+    -ms-flex-preferred-size: 66.66667%;
+        flex-basis: 66.66667%;
+    -ms-flex-positive: 2;
+        flex-grow: 2;
   }
 }
 
@@ -7442,15 +7277,12 @@ ul.pager > li.pager__page a {
 }
 
 .l-action-footer {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row-reverse;
-      -ms-flex-direction: row-reverse;
-          flex-direction: row-reverse;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
 }
 
 .l-action-footer .last-updated {
@@ -7498,14 +7330,12 @@ li.avatar.avatar--default img {
 }
 
 .cc_container {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background: #424242;
   bottom: 0;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
   left: 0;
   overflow: hidden;
   padding: 0.4em 0.8em;
@@ -7514,25 +7344,21 @@ li.avatar.avatar--default img {
 
 .cc_btn {
   font-size: 0.875rem;
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  -ms-flex-item-align: center;
+      align-self: center;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
   font-weight: 600;
-  -webkit-order: 2;
-      -ms-flex-order: 2;
-          order: 2;
+  -ms-flex-order: 2;
+      order: 2;
   margin-left: 1em;
 }
 
 .cc_message {
   font-family: 'Open Sans', Helvetica, Arial, sans-serif;
   font-size: 0.875rem;
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  -ms-flex-item-align: center;
+      align-self: center;
   color: #FFF;
   margin: 0;
 }
@@ -7551,35 +7377,28 @@ li.avatar.avatar--default img {
   z-index: 100;
   margin-top: 1em;
   background: #FFF;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  -ms-flex-direction: column;
+      flex-direction: column;
 }
 
 .degree-programme-switcher .degree-programme-switcher__header {
   border: 1px solid #F8F8F8;
   background: #FFF;
   z-index: 10;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   cursor: pointer;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
   margin: 0;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
+  -ms-flex-align: center;
+      align-items: center;
   padding: 1em;
 }
 
@@ -7589,15 +7408,12 @@ li.avatar.avatar--default img {
 }
 
 .degree-programme-switcher .degree-programme-switcher__title {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -ms-flex: 0 0 80%;
+      flex: 0 0 80%;
 }
 
 .degree-programme-switcher .degree-programme-switcher__toggle {
@@ -7608,25 +7424,20 @@ li.avatar.avatar--default img {
 
 .degree-programme-switcher .degree-programme-switcher__dropdown {
   border: 1px solid #F8F8F8;
-  -webkit-transform: translateY(-100px);
-      -ms-transform: translateY(-100px);
-          transform: translateY(-100px);
+  -ms-transform: translateY(-100px);
+      transform: translateY(-100px);
   opacity: 0;
-  transition: -webkit-transform 0.3s, opacity 0.3s;
   transition: transform 0.3s, opacity 0.3s;
   height: 0;
   overflow: hidden;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   border-top: 0;
   width: 100%;
-  -webkit-flex-grow: 2;
-      -ms-flex-positive: 2;
-          flex-grow: 2;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  -ms-flex-positive: 2;
+      flex-grow: 2;
+  -ms-flex-direction: column;
+      flex-direction: column;
   min-height: 1px;
   background: #FFF;
 }
@@ -7651,9 +7462,8 @@ li.avatar.avatar--default img {
 }
 
 .degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content > div {
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
 }
 
 .degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content ul {
@@ -7713,29 +7523,24 @@ li.avatar.avatar--default img {
 .degree-programme-switcher .degree-programme-switcher__dropdown .button--reset,
 .degree-programme-switcher .degree-programme-switcher__dropdown > h4,
 .degree-programme-switcher .degree-programme-switcher__dropdown > legend {
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
 }
 
 .degree-programme-switcher .degree-programme-switcher__dropdown div {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  -ms-flex-direction: column;
+      flex-direction: column;
   width: 100%;
   min-height: 1px;
 }
 
 .degree-programme-switcher div.degree-programme-switcher__filter {
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  -ms-flex-direction: row;
+      flex-direction: row;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
   max-width: 30em;
 }
 
@@ -7756,9 +7561,8 @@ li.avatar.avatar--default img {
 }
 
 .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
-  -webkit-transform: none;
-      -ms-transform: none;
-          transform: none;
+  -ms-transform: none;
+      transform: none;
   height: auto;
   opacity: 1;
   padding: 1em 1em 0 1em;
@@ -7770,7 +7574,6 @@ li.avatar.avatar--default img {
     display: block;
   }
   .degree-programme-switcher .degree-programme-switcher__icon {
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
   }
@@ -7784,9 +7587,8 @@ li.avatar.avatar--default img {
     max-height: 50vh;
   }
   .degree-programme-switcher .degree-programme-switcher__dropdown .button--reset {
-    -webkit-align-self: flex-end;
-        -ms-flex-item-align: end;
-            align-self: flex-end;
+    -ms-flex-item-align: end;
+        align-self: flex-end;
     margin-bottom: -2em;
   }
   .degree-programme-switcher.collapsed {
@@ -7795,7 +7597,6 @@ li.avatar.avatar--default img {
     position: relative;
   }
   .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
     padding: 2em;
@@ -7825,7 +7626,6 @@ li.avatar.avatar--default img {
 }
 
 .feedback-form .feedback-form__toggle .feedback-form__icon {
-  display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
@@ -7919,11 +7719,6 @@ li.avatar.avatar--default img {
   color: #FFF;
 }
 
-.feedback-form form textarea::-moz-placeholder,
-.feedback-form form input[type="email"]::-moz-placeholder {
-  color: #FFF;
-}
-
 .feedback-form form textarea:-ms-input-placeholder,
 .feedback-form form input[type="email"]:-ms-input-placeholder {
   color: #FFF;
@@ -7940,12 +7735,10 @@ li.avatar.avatar--default img {
 
 .feedback-form form .form-type-checkbox {
   margin-bottom: 1em;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
 }
 
 .feedback-form form input[type="checkbox"] {
@@ -8006,7 +7799,6 @@ input[type="submit"].button--reset {
 
 input[type="submit"].button--reset + i {
   font-size: 0.625rem;
-  display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #0098d0;
@@ -8026,6 +7818,10 @@ input[type="submit"].button--reset + i {
   padding-bottom: 0.4em;
 }
 
+.main-menu {
+  overflow: visible;
+}
+
 @media (min-width: 48em) {
   .main-menu > ul.menu {
     padding-top: 0;
@@ -8036,17 +7832,17 @@ input[type="submit"].button--reset + i {
     padding-bottom: 1.2em;
   }
   .main-menu li.is-expandable {
-    -webkit-align-items: baseline;
-        -ms-flex-align: baseline;
-            align-items: baseline;
+    -ms-flex-align: baseline;
+        align-items: baseline;
   }
   .main-menu li.is-expandable nav {
-    position: fixed;
-    margin-top: 3.4em;
+    position: absolute;
+    top: 55px;
     z-index: 200;
     background: white;
-    width: 100%;
     border-left: 1px solid #D2D2D2;
+    border-bottom: 1px solid #D2D2D2;
+    border-right: 1px solid #D2D2D2;
   }
   .main-menu li.is-lvl1 span[data-drupal-link-system-path] {
     font-size: 0.9375rem;
@@ -8065,6 +7861,12 @@ input[type="submit"].button--reset + i {
 
 .main-menu li.is-lvl1 span[data-drupal-link-system-path] {
   padding: 18px 20px 15px 60px;
+}
+
+@media (min-width: 48em) {
+  .main-menu li.is-lvl2 > a {
+    padding: 20px 30px;
+  }
 }
 
 @media (min-width: 48em) {
@@ -8100,29 +7902,24 @@ input[type="submit"].button--reset + i {
     font-size: 1rem;
     font-weight: 300;
     font-style: normal;
-    -webkit-transform: translate3d(0, 0, 0);
-            transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
     transition: opacity 0.2s ease;
     padding-left: 1em;
   }
 }
 
 .nav-toggle {
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   background: #222;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   font-size: 0;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
   height: 70px;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+      justify-content: center;
   position: relative;
   width: 70px;
   z-index: 15;
@@ -8147,21 +7944,18 @@ input[type="submit"].button--reset + i {
 }
 
 .nav-toggle span:before {
-  -webkit-transform: translateY(-7px);
-      -ms-transform: translateY(-7px);
-          transform: translateY(-7px);
+  -ms-transform: translateY(-7px);
+      transform: translateY(-7px);
 }
 
 .nav-toggle span:after {
-  -webkit-transform: translateY(7px);
-      -ms-transform: translateY(7px);
-          transform: translateY(7px);
+  -ms-transform: translateY(7px);
+      transform: translateY(7px);
 }
 
 .nav-toggle.active span:after, .nav-toggle.active span:before {
-  -webkit-transform: translateY(0);
-      -ms-transform: translateY(0);
-          transform: translateY(0);
+  -ms-transform: translateY(0);
+      transform: translateY(0);
 }
 
 @media (min-width: 48em) {
@@ -8192,8 +7986,7 @@ input[type="submit"].button--reset + i {
   content: "";
   color: #0098d0;
   font-size: 2em;
-  -webkit-animation: icon-spin 2s infinite linear;
-          animation: icon-spin 2s infinite linear;
+  animation: icon-spin 2s infinite linear;
 }
 
 h1, h2, h3, h4, legend,
@@ -8241,7 +8034,6 @@ h1, h2, h3, h4, legend,
 
 @media (min-width: 48em) {
   .main-menu > ul.menu {
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
   }
@@ -8343,7 +8135,6 @@ h1, h2, h3, h4, legend,
 }
 
 .view-search #my-searches .button--reset {
-  display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
@@ -8423,15 +8214,12 @@ h1, h2, h3, h4, legend,
 }
 
 .l-subregion__centered-content {
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -ms-flex-pack: center;
+      justify-content: center;
   margin: 0 auto;
 }
 
@@ -8490,12 +8278,10 @@ h1, h2, h3, h4, legend,
 .theme--box .theme__link-wrapper {
   height: 100%;
   width: 100%;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+      align-items: center;
   padding: 1em;
 }
 

--- a/themes/uhsg_theme/js/fatNavigation.js
+++ b/themes/uhsg_theme/js/fatNavigation.js
@@ -1,0 +1,26 @@
+(function ($) {
+  'use strict';
+  Drupal.behaviors.fatNavigation = {
+    attach: function (context, settings) {
+      var menuToggles = $('.main-menu__expand');
+      var breakpoints = settings.breakpoints;
+
+      menuToggles.once().on('click', function (e) {
+        e.preventDefault();
+        var parentMenuItem = $(this).parent('li');
+        var siblingMenuItems = parentMenuItem.siblings('li');
+        var childMenuItems = parentMenuItem.find('li');
+        parentMenuItem.toggleClass('is-open');
+        childMenuItems.toggle();
+
+        // Hide sibling menu items on larger screens.
+        if (typeof matchMedia !== 'undefined') {
+          var mq = window.matchMedia(breakpoints['small']);
+          if (mq.matches) {
+            siblingMenuItems.toggle();
+          }
+        }
+      });
+    }
+  };
+}(jQuery));

--- a/themes/uhsg_theme/js/fatNavigation.js
+++ b/themes/uhsg_theme/js/fatNavigation.js
@@ -3,23 +3,13 @@
   Drupal.behaviors.fatNavigation = {
     attach: function (context, settings) {
       var menuToggles = $('.main-menu__expand');
-      var breakpoints = settings.breakpoints;
 
       menuToggles.once().on('click', function (e) {
         e.preventDefault();
         var parentMenuItem = $(this).parent('li');
-        var siblingMenuItems = parentMenuItem.siblings('li');
         var childMenuItems = parentMenuItem.find('li');
         parentMenuItem.toggleClass('is-open');
         childMenuItems.toggle();
-
-        // Hide sibling menu items on larger screens.
-        if (typeof matchMedia !== 'undefined') {
-          var mq = window.matchMedia(breakpoints['small']);
-          if (mq.matches) {
-            siblingMenuItems.toggle();
-          }
-        }
       });
     }
   };

--- a/themes/uhsg_theme/sass/components/_main-menu.scss
+++ b/themes/uhsg_theme/sass/components/_main-menu.scss
@@ -1,4 +1,5 @@
 .main-menu {
+  overflow: visible;
   @include breakpoint($small) {
     > ul.menu {
       padding-top: 0;
@@ -14,12 +15,13 @@
       align-items: baseline;
 
       nav {
-        position: fixed;
-        margin-top: 3.4em;
+        position: absolute;
+        top: 55px;
         z-index: 200;
         background: white;
-        width: 100%;
         border-left: 1px solid $mediumsilver;
+        border-bottom: 1px solid $mediumsilver;
+        border-right: 1px solid $mediumsilver;
       }
     }
     li.is-lvl1 span[data-drupal-link-system-path] {
@@ -31,6 +33,14 @@
 
   li.is-lvl1 span[data-drupal-link-system-path] {
     padding: 18px 20px 15px 60px;
+  }
+
+  li.is-lvl2 {
+    > a {
+      @include breakpoint($small) {
+        padding: 20px 30px;
+      }
+    }
   }
 
   li.main-menu__right {

--- a/themes/uhsg_theme/sass/components/_main-menu.scss
+++ b/themes/uhsg_theme/sass/components/_main-menu.scss
@@ -30,7 +30,7 @@
   }
 
   li.is-lvl1 span[data-drupal-link-system-path] {
-    padding: 15px 20px 15px 60px;
+    padding: 18px 20px 15px 60px;
   }
 
   li.main-menu__right {

--- a/themes/uhsg_theme/sass/components/_main-menu.scss
+++ b/themes/uhsg_theme/sass/components/_main-menu.scss
@@ -4,9 +4,11 @@
       padding-top: 0;
       padding-bottom: 0;
     }
-    li.is-lvl1 > a {
-      padding-top: 1.2em;
-      padding-bottom: 1.2em;
+    li.is-lvl1 {
+      > a, span[data-drupal-link-system-path] {
+        padding-top: 1.2em;
+        padding-bottom: 1.2em;
+      }
     }
     li.is-expandable {
       align-items: baseline;
@@ -20,6 +22,15 @@
         border-left: 1px solid $mediumsilver;
       }
     }
+    li.is-lvl1 span[data-drupal-link-system-path] {
+      @include link-menu;
+      padding-right: 1em;
+      padding-left: 1.8em;
+    }
+  }
+
+  li.is-lvl1 span[data-drupal-link-system-path] {
+    padding: 15px 20px 15px 60px;
   }
 
   li.main-menu__right {

--- a/themes/uhsg_theme/sass/components/_main-menu.scss
+++ b/themes/uhsg_theme/sass/components/_main-menu.scss
@@ -10,6 +10,15 @@
     }
     li.is-expandable {
       align-items: baseline;
+
+      nav {
+        position: fixed;
+        margin-top: 3.4em;
+        z-index: 200;
+        background: white;
+        width: 100%;
+        border-left: 1px solid $mediumsilver;
+      }
     }
   }
 

--- a/themes/uhsg_theme/sass/components/_main-menu.scss
+++ b/themes/uhsg_theme/sass/components/_main-menu.scss
@@ -1,13 +1,15 @@
 .main-menu {
   @include breakpoint($small) {
     > ul.menu {
-      max-height: 55px;
       padding-top: 0;
       padding-bottom: 0;
-    }    
+    }
     li.is-lvl1 > a {
       padding-top: 1.2em;
       padding-bottom: 1.2em;
+    }
+    li.is-expandable {
+      align-items: baseline;
     }
   }
 

--- a/themes/uhsg_theme/templates/navigation/menu--main.html.twig
+++ b/themes/uhsg_theme/templates/navigation/menu--main.html.twig
@@ -40,6 +40,18 @@
       {% for item in items %}
         <li{{ item.attributes.addClass(classes) }}>
           {{ link(item.title, item.url, { 'class':[ item.is_active ? 'active' ] }) }}
+          {% if item.below %}
+            <span class="main-menu__expand"></span>
+            <nav role="navigation">
+              <ul{{ attributes }}>
+                {% for child_item in item.below %}
+                  <li{{ child_item.attributes.addClass(classes) }}>
+                    {{ link(child_item.title, child_item.url, { 'class':[ child_item.is_active ? 'active' ] }) }}
+                  </li>
+                {% endfor %}
+              </ul>
+            </nav>
+          {% endif %}
         </li>
       {% endfor %}
 

--- a/themes/uhsg_theme/uhsg_theme.libraries.yml
+++ b/themes/uhsg_theme/uhsg_theme.libraries.yml
@@ -42,6 +42,7 @@ menu_toggle:
   version: 1.x
   js:
     js/responsiveNavigation.js: {}
+    js/fatNavigation.js: {}
   dependencies:
     - core/jquery
     - core/jquery.once

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -117,13 +117,29 @@ function uhsg_theme_preprocess_menu(&$variables) {
 
   if ($menu_classes && $link_classes) {
     $variables['attributes']['class'][] = $menu_classes;
+
     foreach ($variables['items'] as &$item) {
       $item['attributes']->addClass($link_classes);
 
       // we want a different active-class than what drupal provides.
       $current_path = \Drupal::request()->getRequestUri();
+
       if ($item['url']->toString() == $current_path) {
         $item['is_active'] = TRUE;
+      }
+
+      $item_has_children = !empty($item['below']);
+
+      if ($item_has_children) {
+        $item['attributes']->addClass('is-expandable');
+
+        if (isset($item['is_active'])) {
+          $item['attributes']->addClass('is-open');
+        }
+      }
+
+      foreach ($item['below'] as &$child_item) {
+        $child_item['attributes']->addClass('is-lvl2 menu-item');
       }
     }
   }


### PR DESCRIPTION
# Adds support for second level main navigation

## Testing tips

If the main level navigation item has children, the parent needs to be set as `Show as expanded`. Otherwise the child items are not rendered to the DOM at all.

To create a menu item without an actual link, set link field value as `route:<nolink>`.