### PR TITLE
Feature/hub 266 mark instructions for new students

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.13-dev
 Release date: ??.??.????
 
+* Support for marking instructions for new students (HUB-266)
+
 ## 1.12
 Release date: 20.12.2017
 

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.article.body
     - field.field.node.article.field_article_degree_programme
+    - field.field.node.article.field_article_new_students
     - field.field.node.article.field_article_paragraph
     - node.type.article
   module:
@@ -39,6 +40,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_article_new_students:
+    weight: 121
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_article_paragraph:
     type: entity_reference_paragraphs

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.article.body
     - field.field.node.article.field_article_degree_programme
+    - field.field.node.article.field_article_new_students
     - field.field.node.article.field_article_paragraph
     - node.type.article
   module:
@@ -42,8 +43,9 @@ content:
     region: content
   links:
     weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
+  field_article_new_students: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.article.body
     - field.field.node.article.field_article_degree_programme
+    - field.field.node.article.field_article_new_students
     - field.field.node.article.field_article_paragraph
     - node.type.article
   module:
@@ -19,11 +20,21 @@ content:
   body:
     label: hidden
     type: text_summary_or_trimmed
-    weight: 0
+    weight: 1
     settings:
       trim_length: 300
     third_party_settings: {  }
     region: content
+  field_article_new_students:
+    type: boolean
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_true: 'New students'
+      format_custom_false: ''
+    third_party_settings: {  }
 hidden:
   field_article_degree_programme: true
   field_article_paragraph: true

--- a/config/sync/field.field.node.article.field_article_new_students.yml
+++ b/config/sync/field.field.node.article.field_article_new_students.yml
@@ -10,7 +10,7 @@ field_name: field_article_new_students
 entity_type: node
 bundle: article
 label: 'For new students'
-description: 'Is the target audience new students?'
+description: 'New students study in the new degree programmes that started August 1, 2017. Students studying according to the old degree structure are referred to as old students.'
 required: false
 translatable: false
 default_value:

--- a/config/sync/field.field.node.article.field_article_new_students.yml
+++ b/config/sync/field.field.node.article.field_article_new_students.yml
@@ -1,0 +1,23 @@
+uuid: a779570e-1333-424a-ba89-5a2e3a575dd0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_article_new_students
+    - node.type.article
+id: node.article.field_article_new_students
+field_name: field_article_new_students
+entity_type: node
+bundle: article
+label: 'For new students'
+description: 'Is the target audience new students?'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.node.field_article_new_students.yml
+++ b/config/sync/field.storage.node.field_article_new_students.yml
@@ -1,0 +1,18 @@
+uuid: d6a0dc64-5642-41b3-bf43-903534c20e5d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_article_new_students
+field_name: field_article_new_students
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/fi/field.field.node.article.field_article_new_students.yml
+++ b/config/sync/language/fi/field.field.node.article.field_article_new_students.yml
@@ -1,0 +1,2 @@
+label: 'Uudet opiskelijat'
+description: 'Uudet opiskelijat ovat 1.8.2107 aloittaneiden koulutusohjelmien opiskelijoita. Vanhoilla opiskelijoilla tarkoitetaan vanhan koulutusrakenteen mukaisesti opiskelevia.'

--- a/config/sync/language/sv/field.field.node.article.field_article_new_students.yml
+++ b/config/sync/language/sv/field.field.node.article.field_article_new_students.yml
@@ -1,0 +1,2 @@
+label: 'Nya studerande'
+description: 'Nya studerandena studerar i de nya utbildningsprogrammen som startade den 1 augusti 2017. Studerandena som studerar enligt den gamla utbildningsstrukturen är gamla studerandena.'

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8539,6 +8539,16 @@ h1, h2, h3, h4, legend,
   cursor: help;
 }
 
+.article--full .tooltip {
+  position: initial;
+  display: inline-block;
+  margin-bottom: 1em;
+}
+
+.article--full .tooltip-toggle:after {
+  color: #FFF;
+}
+
 .tooltip-toggle {
   font-size: 1.125rem;
   display: inline-block;

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8021,6 +8021,55 @@ input[type="submit"].button--reset + i {
   border: 1px solid #979797;
 }
 
+.description-toggle {
+  font-size: 1.125rem;
+  display: inline-block;
+  position: relative;
+  cursor: help;
+  margin-top: -1em;
+  padding-left: 1em;
+}
+
+.description-toggle:after {
+  display: inline-block;
+  font-family: "hy-icons";
+  font-style: normal;
+  font-weight: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: bottom;
+  content: "";
+  vertical-align: middle;
+  display: inline-block;
+  color: #0098d0;
+}
+
+@media (max-width: 48em) {
+  .description-toggle {
+    float: left;
+    padding-right: 0.5em;
+  }
+}
+
+.description {
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+      hyphens: auto;
+  word-break: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-word;
+  font-size: 0.75em;
+  left: -15px;
+  top: 30px;
+  color: #FFF;
+  position: absolute;
+  padding: 0 1em;
+}
+
+.description.collapsed {
+  padding: 1em;
+}
+
 .list-of-links__compact .list-of-links__link {
   padding-top: 0.4em;
   padding-bottom: 0.4em;

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -7489,7 +7489,7 @@ li.avatar.avatar--default img {
 }
 
 .box-story--no-label.theme-plain {
-  padding: 1.5em;
+  padding: 2.8em 1.5em 1.5em 1.5em;
 }
 
 .cc_banner-wrapper {
@@ -8021,55 +8021,6 @@ input[type="submit"].button--reset + i {
   border: 1px solid #979797;
 }
 
-.description-toggle {
-  font-size: 1.125rem;
-  display: inline-block;
-  position: relative;
-  cursor: help;
-  margin-top: -1em;
-  padding-left: 1em;
-}
-
-.description-toggle:after {
-  display: inline-block;
-  font-family: "hy-icons";
-  font-style: normal;
-  font-weight: normal;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  vertical-align: bottom;
-  content: "";
-  vertical-align: middle;
-  display: inline-block;
-  color: #0098d0;
-}
-
-@media (max-width: 48em) {
-  .description-toggle {
-    float: left;
-    padding-right: 0.5em;
-  }
-}
-
-.description {
-  -webkit-hyphens: auto;
-  -ms-hyphens: auto;
-      hyphens: auto;
-  word-break: break-word;
-  word-wrap: break-word;
-  -ms-word-break: break-word;
-  font-size: 0.75em;
-  left: -15px;
-  top: 30px;
-  color: #FFF;
-  position: absolute;
-  padding: 0 1em;
-}
-
-.description.collapsed {
-  padding: 1em;
-}
-
 .list-of-links__compact .list-of-links__link {
   padding-top: 0.4em;
   padding-bottom: 0.4em;
@@ -8582,4 +8533,48 @@ h1, h2, h3, h4, legend,
 
 .theme--box:hover .theme__teaser-image {
   opacity: 0.25;
+}
+
+.tooltip {
+  cursor: help;
+}
+
+.tooltip-toggle {
+  font-size: 1.125rem;
+  display: inline-block;
+  position: relative;
+  cursor: help;
+  margin-top: -1em;
+  padding-left: 1em;
+}
+
+.tooltip-toggle:after {
+  display: inline-block;
+  font-family: "hy-icons";
+  font-style: normal;
+  font-weight: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: bottom;
+  content: "";
+  vertical-align: middle;
+  display: inline-block;
+  color: #0098d0;
+}
+
+.ui-tooltip {
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+      hyphens: auto;
+  word-break: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-word;
+  background-color: black;
+  font-size: 0.75em;
+  left: -15px;
+  top: 30px;
+  color: #FFF;
+  position: absolute;
+  padding: 1em;
+  border-radius: 10px;
 }

--- a/themes/uhsg_theme/js/tooltip.js
+++ b/themes/uhsg_theme/js/tooltip.js
@@ -2,7 +2,7 @@
   'use strict';
   Drupal.behaviors.tooltip = {
     attach: function (context, settings) {
-      $(document).tooltip();
+      $(document).tooltip({tooltipClass: "description"});
     }
   };
 }(jQuery));

--- a/themes/uhsg_theme/js/tooltip.js
+++ b/themes/uhsg_theme/js/tooltip.js
@@ -2,7 +2,21 @@
   'use strict';
   Drupal.behaviors.tooltip = {
     attach: function (context, settings) {
-      $(document).tooltip({tooltipClass: "description"});
+      var tooltip = $('.tooltip');
+
+      tooltip.on('click', function (event) {
+        event.preventDefault();
+      });
+
+      tooltip.tooltip({
+        open: function (e, ui) {
+          tooltip.not(this).tooltip('close');
+        }
+      });
+
+      $(document).bind('touchstart click', function (event) {
+        tooltip.tooltip('close');
+      });
     }
   };
 }(jQuery));

--- a/themes/uhsg_theme/js/tooltip.js
+++ b/themes/uhsg_theme/js/tooltip.js
@@ -1,0 +1,8 @@
+(function ($) {
+  'use strict';
+  Drupal.behaviors.tooltip = {
+    attach: function (context, settings) {
+      $(document).tooltip();
+    }
+  };
+}(jQuery));

--- a/themes/uhsg_theme/sass/components/_box_story.scss
+++ b/themes/uhsg_theme/sass/components/_box_story.scss
@@ -1,5 +1,5 @@
 .box-story--no-label {
   &.theme-plain {
-    padding: 1.5em;
+    padding: 2.8em 1.5em 1.5em 1.5em;
   }
 }

--- a/themes/uhsg_theme/sass/components/_help-widget.scss
+++ b/themes/uhsg_theme/sass/components/_help-widget.scss
@@ -1,0 +1,31 @@
+.description-toggle {
+  @include font-size(18px);
+  display: inline-block;
+  position: relative;
+  cursor: help;
+  margin-top: -1em;
+  padding-left: 1em;
+  &:after {
+    @include icon($icon-question);
+    vertical-align: middle;
+    display: inline-block;
+    color: $blue;
+  }
+  @include breakpoint($mobile-only) {
+    float: left;
+    padding-right: 0.5em;
+  }
+}
+
+.description {
+  @include hyphenate;
+  font-size: 0.75em;
+  left: -15px;
+  top: 30px;
+  color: $white;
+  position: absolute;
+  padding: 0 1em;
+  &.collapsed {
+    padding: 1em;
+  }
+}

--- a/themes/uhsg_theme/sass/components/_tooltip.scss
+++ b/themes/uhsg_theme/sass/components/_tooltip.scss
@@ -1,4 +1,8 @@
-.description-toggle {
+.tooltip {
+  cursor: help;
+}
+
+.tooltip-toggle {
   @include font-size(18px);
   display: inline-block;
   position: relative;
@@ -11,21 +15,16 @@
     display: inline-block;
     color: $blue;
   }
-  @include breakpoint($mobile-only) {
-    float: left;
-    padding-right: 0.5em;
-  }
 }
 
-.description {
+.ui-tooltip {
   @include hyphenate;
+  background-color: black;
   font-size: 0.75em;
   left: -15px;
   top: 30px;
   color: $white;
   position: absolute;
-  padding: 0 1em;
-  &.collapsed {
-    padding: 1em;
-  }
+  padding: 1em;
+  border-radius: 10px;
 }

--- a/themes/uhsg_theme/sass/components/_tooltip.scss
+++ b/themes/uhsg_theme/sass/components/_tooltip.scss
@@ -2,6 +2,20 @@
   cursor: help;
 }
 
+.article--full {
+  .tooltip {
+    position: initial;
+    display: inline-block;
+    margin-bottom: 1em;
+  }
+
+  .tooltip-toggle {
+    &:after {
+      color: $white;
+    }
+  }
+}
+
 .tooltip-toggle {
   @include font-size(18px);
   display: inline-block;

--- a/themes/uhsg_theme/templates/node/node--article--full.html.twig
+++ b/themes/uhsg_theme/templates/node/node--article--full.html.twig
@@ -90,7 +90,13 @@
   <div{{ content_attributes.addClass(container_classes) }}>
     <div class="col-main">
       <h1> {{ label }} </h1>
-      {{ content|without('field_article_paragraph') }}
+      {% if node.field_article_new_students is not empty and new_students_label is not empty and new_students_description is not empty  %}
+        <div class="box-story__label tooltip" title="{{ new_students_description }}">
+          {{ new_students_label }}
+          <span class="tooltip-toggle"/>
+        </div>
+      {% endif %}
+      {{ content|without('field_article_paragraph', 'field_article_new_students') }}
     </div>
     {% if themes %}
       <div class="col-right">

--- a/themes/uhsg_theme/templates/node/node--teaser.html.twig
+++ b/themes/uhsg_theme/templates/node/node--teaser.html.twig
@@ -92,7 +92,10 @@
         <div class="box-story__label"> {{ type }} </div>
       {% endif %}
       {% if node.field_article_new_students is not empty and new_students_label is not empty and new_students_description is not empty  %}
-        <div class="box-story__label" title="{{ new_students_description }}"> {{ new_students_label }} </div>
+        <div class="box-story__label" title="{{ new_students_description }}">
+          {{ new_students_label }}
+          <span class="description-toggle"/>
+        </div>
       {% endif %}
       {% if content.field_news_image|render %}
         <div class="box-story__image"> {{ content.field_news_image }} </div>

--- a/themes/uhsg_theme/templates/node/node--teaser.html.twig
+++ b/themes/uhsg_theme/templates/node/node--teaser.html.twig
@@ -83,13 +83,16 @@
 {% set created = node.getCreatedTime|format_date('short') %}
 {% set body %}
   {{ content.body }}
-{% endset %}  
+{% endset %}
 
 <div class="grid-item grid-item-3">
   <article {{ attributes.addClass(node_classes) }}>
     <a href="{{ url }}" rel="bookmark" class="box-story__link-wrapper">
       {% if type %}
         <div class="box-story__label"> {{ type }} </div>
+      {% endif %}
+      {% if node.field_article_new_students is not empty and new_students_label is not empty and new_students_description is not empty  %}
+        <div class="box-story__label" title="{{ new_students_description }}"> {{ new_students_label }} </div>
       {% endif %}
       {% if content.field_news_image|render %}
         <div class="box-story__image"> {{ content.field_news_image }} </div>

--- a/themes/uhsg_theme/templates/node/node--teaser.html.twig
+++ b/themes/uhsg_theme/templates/node/node--teaser.html.twig
@@ -92,9 +92,9 @@
         <div class="box-story__label"> {{ type }} </div>
       {% endif %}
       {% if node.field_article_new_students is not empty and new_students_label is not empty and new_students_description is not empty  %}
-        <div class="box-story__label" title="{{ new_students_description }}">
+        <div class="box-story__label tooltip" title="{{ new_students_description }}">
           {{ new_students_label }}
-          <span class="description-toggle"/>
+          <span class="tooltip-toggle"/>
         </div>
       {% endif %}
       {% if content.field_news_image|render %}

--- a/themes/uhsg_theme/uhsg_theme.libraries.yml
+++ b/themes/uhsg_theme/uhsg_theme.libraries.yml
@@ -47,3 +47,10 @@ menu_toggle:
     - core/jquery
     - core/jquery.once
     - core/matchMedia
+
+tooltip:
+  version: 1.x
+  js:
+    js/tooltip.js: {}
+  dependencies:
+    - core/jquery.ui.tooltip

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -327,8 +327,10 @@ function uhsg_theme_preprocess_file_link(&$variables) {
 
 /**
  * Implements template_preprocess_node().
+ *
  * Add node type as label if current page is not a theme.
  * Add referencing themes view.
+ * Add jQuery Tooltip when viewing instructions.
  */
 function uhsg_theme_preprocess_node(&$variables) {
   if (in_array($variables['view_mode'], ['teaser', 'constrained'])) {
@@ -339,6 +341,11 @@ function uhsg_theme_preprocess_node(&$variables) {
   if ($variables['node']->bundle() == 'article' && $variables['page']) {
     $block = \Drupal::service('plugin.manager.block')->createInstance('themes_referencing_instructions', []);
     $variables['themes'] = $block->build();
+  }
+  if ($variables['node']->bundle() == 'article') {
+    $variables['new_students_label'] = t('New students');
+    $variables['new_students_description'] = t('New students study in the new degree programmes that started August 1, 2017. Students studying according to the old degree structure are referred to as old students.');
+    $variables['#attached']['library'][] = 'uhsg_theme/tooltip';
   }
 }
 

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -129,3 +129,9 @@ msgstr "Koulutusohjelmakohtaiset vastaanottoajat"
 
 msgid "Language Centre teachers\' office hours"
 msgstr "Kielikeskuksen opettajien vastaanottoajat"
+
+msgid "New students"
+msgstr "Uudet opiskelijat"
+
+msgid "New students study in the new degree programmes that started August 1, 2017. Students studying according to the old degree structure are referred to as old students."
+msgstr "Uudet opiskelijat ovat 1.8.2107 aloittaneiden koulutusohjelmien opiskelijoita. Vanhoilla opiskelijoilla tarkoitetaan vanhan koulutusrakenteen mukaisesti opiskelevia."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -126,3 +126,9 @@ msgstr "Utbildningsprogramspecifika mottagningstider"
 
 msgid "Language Centre teachers\' office hours"
 msgstr "Lärarnas mottagningstider vid Språkcentrum"
+
+msgid "New students"
+msgstr "Nya studerande"
+
+msgid "New students study in the new degree programmes that started August 1, 2017. Students studying according to the old degree structure are referred to as old students."
+msgstr "Nya studerandena studerar i de nya utbildningsprogrammen som startade den 1 augusti 2017. Studerandena som studerar enligt den gamla utbildningsstrukturen är gamla studerandena."


### PR DESCRIPTION
# Articles for new students

- Articles can now be marked for new students.
- The default is for everyone.
- Article teaser and full view display a label with a tooltip for the articles marked for new students.
- Minor visual modifications to story boxes to make room for the label.
- Remember to test translations (label, tooltip).
- Mobile can be tested using browsersync command (see theme readme). 