### PR TITLE
Feature/hub 318 user groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release date: ??.??.????
 
 * Minor tweaking to caching (HUB-310)
 * Use certificate for oprek integration requests (HUB-319)
+* User groups for themes and instructions (HUB-318)
 
 
 ## 1.18

--- a/config/sync/block.block.generalnews.yml
+++ b/config/sync/block.block.generalnews.yml
@@ -10,7 +10,7 @@ dependencies:
 id: generalnews
 theme: uhsg_theme
 region: after_content
-weight: -9
+weight: -10
 provider: null
 plugin: general_news
 settings:

--- a/config/sync/block.block.newsperdegreeprogramme.yml
+++ b/config/sync/block.block.newsperdegreeprogramme.yml
@@ -1,6 +1,6 @@
 uuid: dbcd0ae6-2d09-4a1e-8684-a616e11d9427
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - system

--- a/config/sync/block.block.newsperdegreeprogramme.yml
+++ b/config/sync/block.block.newsperdegreeprogramme.yml
@@ -10,7 +10,7 @@ dependencies:
 id: newsperdegreeprogramme
 theme: uhsg_theme
 region: after_content
-weight: -10
+weight: -11
 provider: null
 plugin: news_per_degree_programme
 settings:

--- a/config/sync/block.block.newsperdegreeprogramme_2.yml
+++ b/config/sync/block.block.newsperdegreeprogramme_2.yml
@@ -10,7 +10,7 @@ dependencies:
 id: newsperdegreeprogramme_2
 theme: uhsg_theme
 region: after_content
-weight: -8
+weight: -9
 provider: null
 plugin: general_news
 settings:

--- a/config/sync/block.block.themesperusergroup.yml
+++ b/config/sync/block.block.themesperusergroup.yml
@@ -15,7 +15,7 @@ provider: null
 plugin: themes_per_user_group
 settings:
   id: themes_per_user_group
-  label: 'Themes per user group'
+  label: Themes
   provider: uhsg_themes
   label_display: visible
 visibility:

--- a/config/sync/block.block.themesperusergroup.yml
+++ b/config/sync/block.block.themesperusergroup.yml
@@ -1,27 +1,23 @@
-uuid: eece1cd4-af28-4ce6-8a9f-683006607bf1
+uuid: fef1fad6-a572-4edf-85c2-85a66d4fa32d
 langcode: en
 status: true
 dependencies:
-  config:
-    - views.view.themes
   module:
     - system
-    - views
+    - uhsg_themes
   theme:
     - uhsg_theme
-id: views_block__themes_block_1
+id: themesperusergroup
 theme: uhsg_theme
 region: after_content
 weight: -7
 provider: null
-plugin: 'views_block:themes-block_1'
+plugin: themes_per_user_group
 settings:
-  id: 'views_block:themes-block_1'
-  label: ''
-  provider: views
+  id: themes_per_user_group
+  label: 'Themes per user group'
+  provider: uhsg_themes
   label_display: visible
-  views_label: ''
-  items_per_page: none
 visibility:
   request_path:
     id: request_path

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_article_degree_programme
     - field.field.node.article.field_article_new_students
     - field.field.node.article.field_article_paragraph
+    - field.field.node.article.field_user_group
     - node.type.article
   module:
     - paragraphs
@@ -59,6 +60,12 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
     third_party_settings: {  }
+    region: content
+  field_user_group:
+    weight: 122
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_form_display.node.theme.default.yml
+++ b/config/sync/core.entity_form_display.node.theme.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.theme.field_theme_faq
     - field.field.node.theme.field_theme_section
     - field.field.node.theme.field_theme_teaser_image
+    - field.field.node.theme.field_user_group
     - image.style.thumbnail
     - node.type.theme
   module:
@@ -75,6 +76,12 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
+    region: content
+  field_user_group:
+    weight: 121
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_article_degree_programme
     - field.field.node.article.field_article_new_students
     - field.field.node.article.field_article_paragraph
+    - field.field.node.article.field_user_group
     - node.type.article
   module:
     - entity_reference_revisions
@@ -48,4 +49,5 @@ content:
     third_party_settings: {  }
 hidden:
   field_article_new_students: true
+  field_user_group: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.theme.default.yml
+++ b/config/sync/core.entity_view_display.node.theme.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.theme.field_theme_faq
     - field.field.node.theme.field_theme_section
     - field.field.node.theme.field_theme_teaser_image
+    - field.field.node.theme.field_user_group
     - node.type.theme
   module:
     - entity_reference_revisions
@@ -59,4 +60,5 @@ content:
     third_party_settings: {  }
 hidden:
   field_theme_teaser_image: true
+  field_user_group: true
   langcode: true

--- a/config/sync/field.field.node.article.field_user_group.yml
+++ b/config/sync/field.field.node.article.field_user_group.yml
@@ -1,0 +1,21 @@
+uuid: be829b9b-f537-4ea0-8621-fda636a09654
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_user_group
+    - node.type.article
+  module:
+    - options
+id: node.article.field_user_group
+field_name: field_user_group
+entity_type: node
+bundle: article
+label: 'User group'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.theme.field_user_group.yml
+++ b/config/sync/field.field.node.theme.field_user_group.yml
@@ -1,0 +1,21 @@
+uuid: 1f1adfeb-e7f2-4f31-ab4b-c7b6329d32ff
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_user_group
+    - node.type.theme
+  module:
+    - options
+id: node.theme.field_user_group
+field_name: field_user_group
+entity_type: node
+bundle: theme
+label: 'User group'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.node.field_user_group.yml
+++ b/config/sync/field.storage.node.field_user_group.yml
@@ -1,0 +1,30 @@
+uuid: 3dd24c3f-d1aa-42cd-a707-1bbcc0c76ec4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_user_group
+field_name: field_user_group
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: degree_students
+      label: 'Degree Students'
+    -
+      value: doctoral_candidates
+      label: 'Doctoral Candidates'
+    -
+      value: specialist_training
+      label: 'Specialist Training'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/fi/block.block.themesperusergroup.yml
+++ b/config/sync/language/fi/block.block.themesperusergroup.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Teemat

--- a/config/sync/language/fi/field.field.node.theme.field_user_group.yml
+++ b/config/sync/language/fi/field.field.node.theme.field_user_group.yml
@@ -1,0 +1,1 @@
+label: Käyttäjäryhmä

--- a/config/sync/language/fi/field.storage.node.field_user_group.yml
+++ b/config/sync/language/fi/field.storage.node.field_user_group.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: Perustutkinto-opiskelijat
+    -
+      label: Tohtorikoulutettavat
+    -
+      label: 'Ammatillinen jatkokoulutus'

--- a/config/sync/language/fi/views.view.archive.yml
+++ b/config/sync/language/fi/views.view.archive.yml
@@ -9,8 +9,8 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
           expose:

--- a/config/sync/language/fi/views.view.content.yml
+++ b/config/sync/language/fi/views.view.content.yml
@@ -1,8 +1,51 @@
-label: Sisältö
-description: 'Etsi ja ylläpidä sisältöä.'
 display:
   default:
     display_options:
+      fields:
+        field_article_degree_programme:
+          label: 'Koulutusohjelma (ohje)'
+        title:
+          label: Otsikko
+        type:
+          label: Sisältötyyppi
+        name:
+          label: Tekijä
+        status:
+          label: Tila
+          settings:
+            format_custom_true: Julkaistu
+            format_custom_false: Julkaisematon
+        changed:
+          label: Päivitetty
+        operations:
+          label: Toimenpiteet
+      filters:
+        status:
+          group_info:
+            group_items:
+              1:
+                value: '1'
+                title: Julkaistu
+              2:
+                title: Julkaisematon
+            label: Julkaisutila
+          expose:
+            label: Tila
+        field_article_degree_programme_target_id:
+          expose:
+            label: 'Koulutusohjelma (ohje)'
+        uid:
+          expose:
+            label: Tekijä
+        title:
+          expose:
+            label: Otsikko
+        type:
+          expose:
+            label: Sisältötyyppi
+        langcode:
+          expose:
+            label: Kieli
       exposed_form:
         options:
           submit_button: Suodatin
@@ -17,48 +60,6 @@ display:
             next: 'Seuraava ›'
             first: '« Ensimmäinen'
             last: 'Viimeinen »'
-      fields:
-        title:
-          label: Otsikko
-        type:
-          label: Sisältötyyppi
-        name:
-          label: Tekijä
-        status:
-          label: Tila
-        changed:
-          label: Päivitetty
-        operations:
-          label: Toimenpiteet
-        field_article_degree_programme:
-          label: 'Koulutusohjelma (ohje)'
-      filters:
-        status:
-          expose:
-            label: Tila
-          group_info:
-            label: Julkaisutila
-            group_items:
-              1:
-                title: Julkaistu
-                value: '1'
-              2:
-                title: Julkaisematon
-        type:
-          expose:
-            label: Sisältötyyppi
-        title:
-          expose:
-            label: Otsikko
-        langcode:
-          expose:
-            label: Kieli
-        field_article_degree_programme_target_id:
-          expose:
-            label: 'Koulutusohjelma (ohje)'
-        uid:
-          expose:
-            label: Tekijä
       title: Sisältö
       empty:
         area_text_custom:
@@ -71,3 +72,5 @@ display:
       tab_options:
         title: Sisältö
     display_title: Sivu
+label: Sisältö
+description: 'Etsi ja ylläpidä sisältöä.'

--- a/config/sync/language/fi/views.view.content_recent.yml
+++ b/config/sync/language/fi/views.view.content_recent.yml
@@ -8,8 +8,8 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       title: 'Uusin sisältö'
       empty:
         area_text_custom:

--- a/config/sync/language/fi/views.view.files.yml
+++ b/config/sync/language/fi/views.view.files.yml
@@ -8,8 +8,8 @@ display:
           submit_button: Suodatin
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
           tags:
@@ -28,6 +28,9 @@ display:
           label: Koko
         status:
           label: Tila
+          settings:
+            format_custom_false: Tilapäinen
+            format_custom_true: Pysyvä
         created:
           label: Latauspäivämäärä
         count:

--- a/config/sync/language/fi/views.view.frontpage.yml
+++ b/config/sync/language/fi/views.view.frontpage.yml
@@ -3,16 +3,13 @@ description: 'Kaikki etusivulle nostettu sisältö.'
 display:
   default:
     display_options:
-      empty:
-        area_text_custom:
-          content: 'Etusivun sisältöä ei ole vielä luotu.'
       exposed_form:
         options:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
           expose:

--- a/config/sync/language/fi/views.view.glossary.yml
+++ b/config/sync/language/fi/views.view.glossary.yml
@@ -7,8 +7,8 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
           expose:

--- a/config/sync/language/fi/views.view.locked_content.yml
+++ b/config/sync/language/fi/views.view.locked_content.yml
@@ -7,17 +7,17 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
+          tags:
+            previous: ‹‹
+            next: ››
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
       fields:
         title:
           label: Otsikko

--- a/config/sync/language/fi/views.view.taxonomy_term.yml
+++ b/config/sync/language/fi/views.view.taxonomy_term.yml
@@ -8,8 +8,8 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
           expose:

--- a/config/sync/language/fi/views.view.user_admin_people.yml
+++ b/config/sync/language/fi/views.view.user_admin_people.yml
@@ -1,16 +1,29 @@
-label: Käyttäjät
-description: 'Etsi ja hallinnoi sivustoasi käyttäviä ihmisiä.'
 display:
   default:
-    display_title: Isäntä
     display_options:
+      filters:
+        status:
+          group_info:
+            group_items:
+              1:
+                value: '1'
+                title: Voimassa
+              2:
+                title: Suljettu
+            label: Tila
+        roles_target_id:
+          expose:
+            label: Rooli
+        permission:
+          expose:
+            label: Käyttöoikeus
       exposed_form:
         options:
           submit_button: Suodatin
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       pager:
         options:
           tags:
@@ -29,6 +42,9 @@ display:
           label: Käyttäjätunnus
         status:
           label: Tila
+          settings:
+            format_custom_true: Voimassa
+            format_custom_false: Suljettu
         roles_target_id:
           label: Käyttäjäroolit
         created:
@@ -37,27 +53,12 @@ display:
           label: 'Viimeksi paikalla'
         operations:
           label: Toimenpiteet
-      filters:
-        roles_target_id:
-          expose:
-            label: Rooli
-        permission:
-          expose:
-            label: Käyttöoikeus
-        status:
-          group_info:
-            label: Tila
-            group_items:
-              1:
-                title: Voimassa
-                value: '1'
-              2:
-                title: Suljettu
       title: Käyttäjät
       empty:
         area_text_custom:
           content: 'Ei saatavilla olevia ihmisiä.'
       use_more_text: lisää
+    display_title: Isäntä
   page_1:
     display_title: Sivu
     display_options:
@@ -67,3 +68,5 @@ display:
       tab_options:
         title: Käyttäjät
         description: 'Ylläpidä käyttäjiä, rooleja ja käyttöoikeuksia.'
+label: Käyttäjät
+description: 'Etsi ja hallinnoi sivustoasi käyttäviä ihmisiä.'

--- a/config/sync/language/fi/views.view.who_s_new.yml
+++ b/config/sync/language/fi/views.view.who_s_new.yml
@@ -8,8 +8,8 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       title: 'Uudet käyttäjät'
   block_1:
     display_title: 'Uudet käyttäjät'

--- a/config/sync/language/fi/views.view.who_s_online.yml
+++ b/config/sync/language/fi/views.view.who_s_online.yml
@@ -7,8 +7,8 @@ display:
           submit_button: Käytä
           reset_button_label: 'Palauta oletusarvoihin'
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
       filters:
         access:
           expose:

--- a/config/sync/language/sv/block.block.themesperusergroup.yml
+++ b/config/sync/language/sv/block.block.themesperusergroup.yml
@@ -1,0 +1,2 @@
+settings:
+  label: Teman

--- a/config/sync/language/sv/field.field.node.theme.field_user_group.yml
+++ b/config/sync/language/sv/field.field.node.theme.field_user_group.yml
@@ -1,0 +1,1 @@
+label: Användargrupp

--- a/config/sync/language/sv/field.storage.node.field_user_group.yml
+++ b/config/sync/language/sv/field.storage.node.field_user_group.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: Grundexamensstuderande
+    -
+      label: Doktorander
+    -
+      label: 'Yrkesinriktad påbyggnadsutbildning'

--- a/config/sync/language/sv/views.view.content.yml
+++ b/config/sync/language/sv/views.view.content.yml
@@ -1,8 +1,27 @@
-label: Innehåll
-description: 'Hitta och hantera innehåll.'
 display:
   default:
     display_options:
+      filters:
+        status:
+          group_info:
+            group_items:
+              1:
+                value: '1'
+                title: Publicerad
+              2:
+                title: 'Ej publicerad'
+            label: 'Status för publicering'
+          expose:
+            label: Status
+        title:
+          expose:
+            label: Titel
+        type:
+          expose:
+            label: Innehållstyp
+        langcode:
+          expose:
+            label: Språk
       exposed_form:
         options:
           submit_button: Filtrera
@@ -27,29 +46,11 @@ display:
           label: Författare
         status:
           label: Status
+          settings:
+            format_custom_true: Publicerad
+            format_custom_false: 'Ej publicerad'
         operations:
           label: Funktioner
-      filters:
-        status:
-          expose:
-            label: Status
-          group_info:
-            label: 'Status för publicering'
-            group_items:
-              1:
-                title: Publicerad
-                value: '1'
-              2:
-                title: 'Ej publicerad'
-        type:
-          expose:
-            label: Innehållstyp
-        title:
-          expose:
-            label: Titel
-        langcode:
-          expose:
-            label: Språk
       title: Innehåll
       empty:
         area_text_custom:
@@ -63,3 +64,5 @@ display:
         title: Innehåll
         description: 'Hitta och hantera innehåll'
     display_title: Sida
+label: Innehåll
+description: 'Hitta och hantera innehåll.'

--- a/config/sync/language/sv/views.view.files.yml
+++ b/config/sync/language/sv/views.view.files.yml
@@ -32,6 +32,9 @@ display:
           label: Storlek
         status:
           label: Status
+          settings:
+            format_custom_false: Temporär
+            format_custom_true: Permanent
         created:
           label: 'Datum för uppladdning'
         changed:

--- a/config/sync/language/sv/views.view.frontpage.yml
+++ b/config/sync/language/sv/views.view.frontpage.yml
@@ -4,8 +4,6 @@ display:
   default:
     display_options:
       empty:
-        area_text_custom:
-          content: 'Inget innehåll för startsidan har skapats ännu.'
         title:
           title: 'Välkommen till [site:name]'
       exposed_form:

--- a/config/sync/language/sv/views.view.locked_content.yml
+++ b/config/sync/language/sv/views.view.locked_content.yml
@@ -11,13 +11,13 @@ display:
           sort_desc_label: Fallande
       pager:
         options:
+          tags:
+            previous: ‹‹
+            next: ››
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'
             offset_label: Kompensera
-          tags:
-            previous: ‹‹
-            next: ››
       fields:
         title:
           label: Titel

--- a/config/sync/language/sv/views.view.user_admin_people.yml
+++ b/config/sync/language/sv/views.view.user_admin_people.yml
@@ -1,9 +1,25 @@
-label: Personer
-description: 'Hitta och hantera personer som använder din webbplats.'
 display:
   default:
-    display_title: Huvud
     display_options:
+      filters:
+        status:
+          group_info:
+            group_items:
+              1:
+                value: '1'
+                title: Aktiv
+              2:
+                title: Spärrad
+            label: Status
+        combine:
+          expose:
+            label: 'Namn eller e-post innehåller'
+        roles_target_id:
+          expose:
+            label: Roll
+        permission:
+          expose:
+            label: Behörighet
       exposed_form:
         options:
           submit_button: Filtrera
@@ -29,6 +45,9 @@ display:
           label: Användarnamn
         status:
           label: Status
+          settings:
+            format_custom_true: Aktiv
+            format_custom_false: Spärrad
         roles_target_id:
           label: Roller
         created:
@@ -39,30 +58,12 @@ display:
           label: Funktioner
         mail:
           separator: ', '
-      filters:
-        combine:
-          expose:
-            label: 'Namn eller e-post innehåller'
-        roles_target_id:
-          expose:
-            label: Roll
-        permission:
-          expose:
-            label: Behörighet
-        status:
-          group_info:
-            label: Status
-            group_items:
-              1:
-                title: Aktiv
-                value: '1'
-              2:
-                title: Spärrad
       title: Personer
       empty:
         area_text_custom:
           content: 'Inga personer tillgängliga.'
       use_more_text: mer
+    display_title: Huvud
   page_1:
     display_title: Sida
     display_options:
@@ -72,3 +73,5 @@ display:
       tab_options:
         title: Personer
         description: 'Hantera användarkonton, roller och behörigheter.'
+label: Personer
+description: 'Hitta och hantera personer som använder din webbplats.'

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_article_degree_programme
+    - field.storage.node.field_user_group
     - taxonomy.vocabulary.degree_programme
   module:
     - node
+    - options
     - taxonomy
     - user
+    - view_unpublished
 _core:
   default_config_hash: ikQgJA-GO0ni32wrs5t5AyQ5T7kNB6vgaJyTVEXHeT4
 id: content
@@ -346,6 +349,68 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_user_group:
+          id: field_user_group
+          table: node__field_user_group
+          field: field_user_group
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'User group'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         operations:
           id: operations
           table: node
@@ -660,6 +725,48 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
+        field_user_group_value:
+          id: field_user_group_value
+          table: node__field_user_group
+          field: field_user_group_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_user_group_value_op
+            label: 'User group'
+            description: ''
+            use_operator: false
+            operator: field_user_group_value_op
+            identifier: field_user_group_value
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              bulletin_manager: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
       sorts: {  }
       title: Content
       empty:
@@ -701,6 +808,7 @@ display:
       max-age: 0
       tags:
         - 'config:field.storage.node.field_article_degree_programme'
+        - 'config:field.storage.node.field_user_group'
   page_1:
     display_options:
       path: admin/content/node
@@ -734,3 +842,4 @@ display:
       max-age: 0
       tags:
         - 'config:field.storage.node.field_article_degree_programme'
+        - 'config:field.storage.node.field_user_group'

--- a/config/sync/views.view.themes.yml
+++ b/config/sync/views.view.themes.yml
@@ -9,6 +9,7 @@ dependencies:
   module:
     - draggableviews
     - node
+    - options
     - user
 id: themes
 label: Themes
@@ -212,6 +213,378 @@ display:
       display_extenders: {  }
       defaults:
         access: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_2:
+    display_plugin: block
+    id: block_2
+    display_title: 'Degree Students'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      defaults:
+        access: true
+        filters: false
+        filter_groups: false
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            theme: theme
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_user_group_value:
+          id: field_user_group_value
+          table: node__field_user_group
+          field: field_user_group_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            degree_students: degree_students
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_3:
+    display_plugin: block
+    id: block_3
+    display_title: 'Doctoral Candidates'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      defaults:
+        access: true
+        filters: false
+        filter_groups: false
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            theme: theme
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_user_group_value:
+          id: field_user_group_value
+          table: node__field_user_group
+          field: field_user_group_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            doctoral_candidates: doctoral_candidates
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_4:
+    display_plugin: block
+    id: block_4
+    display_title: 'Specialist Training'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      defaults:
+        access: true
+        filters: false
+        filter_groups: false
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            theme: theme
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_user_group_value:
+          id: field_user_group_value
+          table: node__field_user_group
+          field: field_user_group_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            specialist_training: specialist_training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.themes.yml
+++ b/config/sync/views.view.themes.yml
@@ -221,9 +221,9 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  block_2:
+  degree_students:
     display_plugin: block
-    id: block_2
+    id: degree_students
     display_title: 'Degree Students'
     position: 2
     display_options:
@@ -345,9 +345,9 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  block_3:
+  doctoral_candidates:
     display_plugin: block
-    id: block_3
+    id: doctoral_candidates
     display_title: 'Doctoral Candidates'
     position: 2
     display_options:
@@ -428,130 +428,6 @@ display:
           operator: or
           value:
             doctoral_candidates: doctoral_candidates
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          plugin_id: list_field
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
-  block_4:
-    display_plugin: block
-    id: block_4
-    display_title: 'Specialist Training'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      defaults:
-        access: true
-        filters: false
-        filter_groups: false
-      display_description: ''
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            theme: theme
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-        field_user_group_value:
-          id: field_user_group_value
-          table: node__field_user_group
-          field: field_user_group_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            specialist_training: specialist_training
           group: 1
           exposed: false
           expose:
@@ -821,6 +697,130 @@ display:
         menu_name: admin
     cache_metadata:
       max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  specialist_training:
+    display_plugin: block
+    id: specialist_training
+    display_title: 'Specialist Training'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      defaults:
+        access: true
+        filters: false
+        filter_groups: false
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            theme: theme
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_user_group_value:
+          id: field_user_group_value
+          table: node__field_user_group
+          field: field_user_group_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            specialist_training: specialist_training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/modules/uhsg_themes/src/Plugin/Block/ThemesPerUserGroup.php
+++ b/modules/uhsg_themes/src/Plugin/Block/ThemesPerUserGroup.php
@@ -30,12 +30,17 @@ class ThemesPerUserGroup extends BlockBase {
   }
 
   private function renderContent() {
-    $view = Views::getView('themes');
-
     return [
-      'degree_students' => $view->render('degree_students'),
-      'doctoral_candidates' => $view->render('doctoral_candidates'),
-      'specialist_training' => $view->render('specialist_training')
+      'degree_students' => $this->renderDisplay('degree_students'),
+      'doctoral_candidates' => $this->renderDisplay('doctoral_candidates'),
+      'specialist_training' => $this->renderDisplay('specialist_training'),
     ];
+  }
+
+  private function renderDisplay($displayId) {
+    $view = Views::getView('themes');
+    $view->setDisplay($displayId);
+
+    return $view->buildRenderable();
   }
 }

--- a/modules/uhsg_themes/src/Plugin/Block/ThemesPerUserGroup.php
+++ b/modules/uhsg_themes/src/Plugin/Block/ThemesPerUserGroup.php
@@ -19,17 +19,10 @@ class ThemesPerUserGroup extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    return $this->render();
+    return ['content' => $this->render()];
   }
 
   private function render() {
-    $renderableArray = [];
-    $renderableArray['content'] = $this->renderContent();
-
-    return $renderableArray;
-  }
-
-  private function renderContent() {
     return [
       'degree_students' => $this->renderDisplay('degree_students'),
       'doctoral_candidates' => $this->renderDisplay('doctoral_candidates'),

--- a/modules/uhsg_themes/src/Plugin/Block/ThemesPerUserGroup.php
+++ b/modules/uhsg_themes/src/Plugin/Block/ThemesPerUserGroup.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\uhsg_themes\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\views\Views;
+
+/**
+ * Provides a 'themes_per_user_group' block.
+ *
+ * @Block(
+ *  id = "themes_per_user_group",
+ *  admin_label = @Translation("Themes per user group"),
+ * )
+ */
+class ThemesPerUserGroup extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return $this->render();
+  }
+
+  private function render() {
+    $renderableArray = [];
+    $renderableArray['content'] = $this->renderContent();
+
+    return $renderableArray;
+  }
+
+  private function renderContent() {
+    $view = Views::getView('themes');
+
+    return [
+      'degree_students' => $view->render('degree_students'),
+      'doctoral_candidates' => $view->render('doctoral_candidates'),
+      'specialist_training' => $view->render('specialist_training')
+    ];
+  }
+}

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -9274,6 +9274,10 @@ h1, h2, h3, h4, legend, .logo-block__content .logo-block__sitename,
   margin: 0 auto;
 }
 
+.ui-tabs .ui-tabs-nav li {
+  margin: 0;
+}
+
 .tag-list {
   -webkit-hyphens: auto;
   -ms-hyphens: auto;

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8083,6 +8083,132 @@ input[type="text"].search-form-large__input {
   color: #FFF;
 }
 
+/*
+ section: 6.7
+ title: Horizontal tabs
+ template: 6_7_horizontal-tabs
+ description:
+*/
+.horizontal-tabs .horizontal-tabs-list {
+  -ms-flex-align: center;
+      align-items: center;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: row;
+      flex-direction: row;
+  margin-bottom: 30px;
+  overflow: hidden;
+  position: relative;
+}
+
+@media (min-width: 48em) {
+  .horizontal-tabs .horizontal-tabs-list {
+    margin-bottom: 60px;
+  }
+}
+
+.horizontal-tabs .horizontal-tabs-pane {
+  min-width: 0;
+}
+
+.horizontal-tabs .horizontal-tabs-pane legend {
+  display: none;
+}
+
+.horizontal-tabs .horizontal-tab-button {
+  border: 1px solid #eaeaea;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex-positive: 1;
+      flex-grow: 1;
+  margin: 0;
+  text-align: center;
+}
+
+.horizontal-tabs .horizontal-tab-button:not(:last-child) {
+  border-right: none;
+}
+
+.horizontal-tabs .horizontal-tab-button > a {
+  font-size: 0.875rem;
+  -ms-flex-align: center;
+      align-items: center;
+  background: #F8F8F8;
+  color: #979797;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  font-weight: 600;
+  height: 5rem;
+  -ms-flex-pack: center;
+      justify-content: center;
+  padding: 0;
+  transition-duration: 0.2s;
+  transition-property: color, background-color;
+}
+
+.horizontal-tabs .horizontal-tab-button > a > strong {
+  font-weight: 400;
+}
+
+.horizontal-tabs .horizontal-tab-button > a[href='#programme']:before {
+  display: inline-block;
+  font-family: "hy-icons";
+  font-style: normal;
+  font-weight: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: bottom;
+  content: "";
+  font-size: 2em;
+  margin-bottom: 5px;
+}
+
+.horizontal-tabs .horizontal-tab-button > a[href='#applying']:before {
+  display: inline-block;
+  font-family: "hy-icons";
+  font-style: normal;
+  font-weight: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: bottom;
+  content: "";
+  font-size: 2em;
+  margin-bottom: 5px;
+}
+
+.horizontal-tabs .horizontal-tab-button > a[href='#organisation']:before {
+  display: inline-block;
+  font-family: "hy-icons";
+  font-style: normal;
+  font-weight: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: bottom;
+  content: "";
+  font-size: 2em;
+  margin-bottom: 5px;
+}
+
+.horizontal-tabs .horizontal-tab-button.selected {
+  border-top-color: #0098d0;
+  border-bottom-color: transparent;
+  z-index: 2;
+}
+
+.horizontal-tabs .horizontal-tab-button.selected a {
+  background-color: #FFF;
+  box-shadow: inset 0 3px 0 #0098d0;
+  color: #0098d0;
+}
+
+.horizontal-tabs .horizontal-tab-button:hover > a {
+  color: #0098d0;
+}
+
 /* STUDENT GUIDE THEMING */
 .container {
   margin: 0 auto;

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -9287,7 +9287,14 @@ h1, h2, h3, h4, legend, .logo-block__content .logo-block__sitename,
 }
 
 .ui-tabs .ui-tabs-nav li {
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+      hyphens: auto;
+  word-break: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-word;
   margin: 0;
+  white-space: normal;
 }
 
 .ui-tabs .ui-tabs-panel {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8362,6 +8362,14 @@ input[type="text"].search-form-large__input {
   }
 }
 
+.path-frontpage .l-subregion-wrapper {
+  padding-top: 0;
+}
+
+.path-frontpage .l-subregion-wrapper:nth-of-type(odd) {
+  background-color: transparent;
+}
+
 .accordion__accordion-body {
   margin-bottom: 1em;
 }

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8362,6 +8362,10 @@ input[type="text"].search-form-large__input {
   }
 }
 
+.l-subregion {
+  padding: 0;
+}
+
 .path-frontpage .l-subregion-wrapper {
   padding-top: 0;
 }
@@ -9284,6 +9288,10 @@ h1, h2, h3, h4, legend, .logo-block__content .logo-block__sitename,
 
 .ui-tabs .ui-tabs-nav li {
   margin: 0;
+}
+
+.ui-tabs .ui-tabs-panel {
+  padding: 0;
 }
 
 .tag-list {

--- a/themes/uhsg_theme/js/tabs.js
+++ b/themes/uhsg_theme/js/tabs.js
@@ -1,5 +1,7 @@
 (function ($) {
   'use strict';
+
+  // Initializes jQuery UI Tabs.
   Drupal.behaviors.tabs = {
     attach: function (context, settings) {
       $('#tabs').once('tabs').tabs({

--- a/themes/uhsg_theme/js/tabs.js
+++ b/themes/uhsg_theme/js/tabs.js
@@ -2,7 +2,11 @@
   'use strict';
   Drupal.behaviors.tabs = {
     attach: function (context, settings) {
-      $('#tabs').once('tabs').tabs();
+      $('#tabs').once('tabs').tabs({
+        classes: {
+          'ui-tabs-active': 'selected'
+        }
+      });
     }
   };
 }(jQuery));

--- a/themes/uhsg_theme/js/tabs.js
+++ b/themes/uhsg_theme/js/tabs.js
@@ -1,0 +1,8 @@
+(function ($) {
+  'use strict';
+  Drupal.behaviors.tabs = {
+    attach: function (context, settings) {
+      $('#tabs').once('tabs').tabs();
+    }
+  };
+}(jQuery));

--- a/themes/uhsg_theme/sass/components/_tabs.scss
+++ b/themes/uhsg_theme/sass/components/_tabs.scss
@@ -1,0 +1,3 @@
+.ui-tabs .ui-tabs-nav li {
+  margin: 0;
+}

--- a/themes/uhsg_theme/sass/components/_tabs.scss
+++ b/themes/uhsg_theme/sass/components/_tabs.scss
@@ -1,6 +1,8 @@
 .ui-tabs {
   .ui-tabs-nav li {
+    @include hyphenate;
     margin: 0;
+    white-space: normal;
   }
 
   .ui-tabs-panel {

--- a/themes/uhsg_theme/sass/components/_tabs.scss
+++ b/themes/uhsg_theme/sass/components/_tabs.scss
@@ -1,3 +1,9 @@
-.ui-tabs .ui-tabs-nav li {
-  margin: 0;
+.ui-tabs {
+  .ui-tabs-nav li {
+    margin: 0;
+  }
+
+  .ui-tabs-panel {
+    padding: 0;
+  }
 }

--- a/themes/uhsg_theme/sass/layout/common/_l-subregion.scss
+++ b/themes/uhsg_theme/sass/layout/common/_l-subregion.scss
@@ -1,0 +1,8 @@
+.path-frontpage .l-subregion-wrapper {
+  padding-top: 0;
+
+  &:nth-of-type(odd) {
+    background-color: transparent;
+  }
+}
+

--- a/themes/uhsg_theme/sass/layout/common/_l-subregion.scss
+++ b/themes/uhsg_theme/sass/layout/common/_l-subregion.scss
@@ -1,3 +1,7 @@
+.l-subregion {
+  padding: 0;
+}
+
 .path-frontpage .l-subregion-wrapper {
   padding-top: 0;
 

--- a/themes/uhsg_theme/sass/style.scss
+++ b/themes/uhsg_theme/sass/style.scss
@@ -33,6 +33,7 @@
 @import "styleguide/components/_tag-list.scss";
 @import "styleguide/components/_textarea.scss";
 @import "styleguide/components/_search-form.scss";
+@import "styleguide/components/_horizontal-tabs.scss";
 
 /* STUDENT GUIDE THEMING */
 @import "variables/**/*";

--- a/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
+++ b/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
@@ -1,0 +1,89 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+    'l-subregion-wrapper'
+  ]
+%}
+
+{%
+  set title_classes = [
+    'l-subregion__title',
+    'is-center-mobile'
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  <div class="l-subregion">
+    {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+    {% endif %}
+    {{ title_suffix }}
+    <div{{ content_attributes }}>
+      {% block content %}
+        <div id="tabs" class="horizontal-tabs clearfix">
+          <ul class="horizontal-tabs-list">
+            <li class="horizontal-tab-button horizontal-tab-button-0 first" tabindex="-1">
+              <a href="#degree_students">
+                <strong>{{ 'Degree Students'|trans }}</strong>
+                <span class="summary"></span>
+                <span id="active-horizontal-tab" class="element-invisible">(active tab)</span>
+              </a>
+            </li>
+            <li class="horizontal-tab-button horizontal-tab-button-1" tabindex="-1">
+              <a href="#doctoral_students">
+                <strong>{{ 'Doctoral Students'|trans }}</strong>
+                <span class="summary"></span>
+              </a>
+            </li>
+            <li class="horizontal-tab-button horizontal-tab-button-2 last" tabindex="-1">
+              <a href="#specialist_training">
+                <strong>{{ 'Specialist Training'|trans }}</strong>
+                <span class="summary"></span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div id="degree_students">
+          {{ content['degree_students'] }}
+        </div>
+        <div id="doctoral_candidates">
+          {{ content['doctoral_candidates'] }}
+        </div>
+        <div id="specialist_training">
+          {{ content['specialist_training'] }}
+        </div>
+      {% endblock %}
+    </div>
+    {{ content['#suffix'] }}
+  </div>
+</div>

--- a/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
+++ b/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
@@ -69,19 +69,23 @@
             </a>
           </li>
         </ul>
-        {{ news_per_degree_programme }}
-        {{ title_prefix }}
-        {% if label %}
-          <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
-        {% endif %}
-        {{ title_suffix }}
         <div id="degree_students">
+          {{ news_per_degree_programme }}
+          {% block title_block %}
+            {{ title_prefix }}
+            {% if label %}
+              <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+            {% endif %}
+            {{ title_suffix }}
+          {% endblock %}
           {{ content['content']['degree_students'] }}
         </div>
         <div id="doctoral_candidates">
+          {{ block('title_block') }}
           {{ content['content']['doctoral_candidates'] }}
         </div>
         <div id="specialist_training">
+          {{ block('title_block') }}
           {{ content['content']['specialist_training'] }}
         </div>
       </div>

--- a/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
+++ b/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
@@ -25,6 +25,9 @@
  * @see template_preprocess_block()
  */
 #}
+
+{{ attach_library('uhsg_theme/tabs') }}
+
 {%
   set classes = [
     'block',
@@ -43,46 +46,44 @@
 
 <div{{ attributes.addClass(classes) }}>
   <div class="l-subregion">
-    {{ title_prefix }}
-    {% if label %}
-      <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
-    {% endif %}
-    {{ title_suffix }}
     <div{{ content_attributes }}>
-      {% block content %}
-        <div id="tabs" class="horizontal-tabs clearfix">
-          <ul class="horizontal-tabs-list">
-            <li class="horizontal-tab-button horizontal-tab-button-0 first" tabindex="-1">
-              <a href="#degree_students">
-                <strong>{{ 'Degree Students'|trans }}</strong>
-                <span class="summary"></span>
-                <span id="active-horizontal-tab" class="element-invisible">(active tab)</span>
-              </a>
-            </li>
-            <li class="horizontal-tab-button horizontal-tab-button-1" tabindex="-1">
-              <a href="#doctoral_students">
-                <strong>{{ 'Doctoral Students'|trans }}</strong>
-                <span class="summary"></span>
-              </a>
-            </li>
-            <li class="horizontal-tab-button horizontal-tab-button-2 last" tabindex="-1">
-              <a href="#specialist_training">
-                <strong>{{ 'Specialist Training'|trans }}</strong>
-                <span class="summary"></span>
-              </a>
-            </li>
-          </ul>
-        </div>
+      <div id="tabs" class="horizontal-tabs clearfix">
+        <ul class="horizontal-tabs-list">
+          <li class="horizontal-tab-button horizontal-tab-button-0 first" tabindex="-1">
+            <a href="#degree_students">
+              <strong>{{ 'Degree Students'|trans }}</strong>
+              <span class="summary"></span>
+              <span id="active-horizontal-tab" class="element-invisible">(active tab)</span>
+            </a>
+          </li>
+          <li class="horizontal-tab-button horizontal-tab-button-1" tabindex="-1">
+            <a href="#doctoral_candidates">
+              <strong>{{ 'Doctoral Candidates'|trans }}</strong>
+              <span class="summary"></span>
+            </a>
+          </li>
+          <li class="horizontal-tab-button horizontal-tab-button-2 last" tabindex="-1">
+            <a href="#specialist_training">
+              <strong>{{ 'Specialist Training'|trans }}</strong>
+              <span class="summary"></span>
+            </a>
+          </li>
+        </ul>
+        {{ title_prefix }}
+        {% if label %}
+          <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+        {% endif %}
+        {{ title_suffix }}
         <div id="degree_students">
-          {{ content['degree_students'] }}
+          {{ content['content']['degree_students'] }}
         </div>
         <div id="doctoral_candidates">
-          {{ content['doctoral_candidates'] }}
+          {{ content['content']['doctoral_candidates'] }}
         </div>
         <div id="specialist_training">
-          {{ content['specialist_training'] }}
+          {{ content['content']['specialist_training'] }}
         </div>
-      {% endblock %}
+      </div>
     </div>
     {{ content['#suffix'] }}
   </div>

--- a/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
+++ b/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
@@ -69,6 +69,7 @@
             </a>
           </li>
         </ul>
+        {{ news_per_degree_programme }}
         {{ title_prefix }}
         {% if label %}
           <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>

--- a/themes/uhsg_theme/uhsg_theme.libraries.yml
+++ b/themes/uhsg_theme/uhsg_theme.libraries.yml
@@ -62,3 +62,10 @@ truncateText:
   dependencies:
     - core/jquery
 
+tabs:
+  version: 1.x
+  js:
+    js/tabs.js: {}
+  dependencies:
+    - core/jquery.once
+    - core/jquery.ui.tabs

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -286,6 +286,9 @@ function uhsg_theme_preprocess_block(array &$variables) {
       ];
 
       break;
+    case 'themesperusergroup':
+      $variables['news_per_degree_programme'] = _uhsg_theme_get_news_per_degree_programme();
+      break;
   }
 }
 
@@ -455,4 +458,12 @@ function _uhsg_theme_get_degree_programme_switcher() {
     return '';
   }
   return \Drupal::entityTypeManager()->getViewBuilder('block')->view($degree_programme_switcher);
+}
+
+function _uhsg_theme_get_news_per_degree_programme() {
+  $news_per_degree_programme = \Drupal\block\Entity\Block::load('newsperdegreeprogramme');
+
+  return $news_per_degree_programme
+    ? \Drupal::entityTypeManager()->getViewBuilder('block')->view($news_per_degree_programme)
+    : '';
 }

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -141,3 +141,12 @@ msgstr "Hae ohjetta hakusanalla (tai sanan alkuosalla)"
 
 msgid "Copy URL"
 msgstr "Kopioi URL"
+
+msgid "Degree Students"
+msgstr "Perustutkinto-opiskelijat"
+
+msgid "Doctoral Candidates"
+msgstr "Tohtorikoulutettavat"
+
+msgid "Specialist Training"
+msgstr "Ammatillinen jatkokoulutus"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -138,3 +138,12 @@ msgstr "Sök anvisningar efter ord (eller första delen av ordet)"
 
 msgid "Copy URL"
 msgstr "Kopiera URL"
+
+msgid "Degree Students"
+msgstr "Grundexamensstuderande"
+
+msgid "Doctoral Candidates"
+msgstr "Doktorander"
+
+msgid "Specialist Training"
+msgstr "Yrkesinriktad påbyggnadsutbildning"


### PR DESCRIPTION
# User groups for themes and instructions

- Added a new field: User group.
- Attached the field to Theme and Instruction (required).
- Refactored front page theme listing: Tab per user group.
- Degree programme specific news relocated. Displayed when degree students tab is active.

Testing:

- Import translations.
- Edit some Themes. Assign user groups.
- Verify that Themes fall under correct groups on front page.