### PR TITLE
HUB-319: Use certificate for oprek requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Release date: ??.??.????
 
 * Minor tweaking to caching (HUB-310)
+* Use certificate for oprek integration requests (HUB-319)
 
 
 ## 1.18

--- a/modules/uhsg_oprek/config/install/uhsg_oprek.settings.yml
+++ b/modules/uhsg_oprek/config/install/uhsg_oprek.settings.yml
@@ -1,1 +1,3 @@
 base_url: ''
+cert_filepath: ''
+cert_key_filepath: ''

--- a/modules/uhsg_oprek/config/schema/uhsg_oprek.settings.schema.yml
+++ b/modules/uhsg_oprek/config/schema/uhsg_oprek.settings.schema.yml
@@ -7,3 +7,9 @@ uhsg_oprek.settings:
     base_url:
       type: string
       label: 'Endpoint base URL where all REST requests are sent to without trailing slash.'
+    cert_filepath: ''
+      type: string
+      label: 'Filepath to certificate file (PEM format).'
+    cert_key_filepath: ''
+      type: string
+      label: 'Filepath to certificate\'s key file.'

--- a/modules/uhsg_oprek/src/Oprek/OprekService.php
+++ b/modules/uhsg_oprek/src/Oprek/OprekService.php
@@ -72,7 +72,7 @@ class OprekService implements OprekServiceInterface {
       $uri = str_replace($key, $value, $uri);
     }
 
-    $response = $this->client->get($this->config->get('base_url') . $uri);
+    $response = $this->client->get($this->config->get('base_url') . $uri, ['cert' => $this->config->get('cert_filepath'), 'ssl_key' => $this->config->get('cert_key_filepath')]);
     if ($response->getStatusCode() == 200) {
       $body = Json::decode($response->getBody()->getContents());
       if ($this->getStatusFromBody($body) == 200) {


### PR DESCRIPTION
* Download certificate and key file to your environment for testing (use SSH tunneling if needed)
* Change `base_url` configuration to prefix with `/secure` endpoint
* Configure your certificate file and key file paths for the module in `settings.local.php`
