### PR TITLE
Feature/hub 320 degree programme user group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Release date: ??.??.????
 * Use certificate for oprek integration requests (HUB-319)
 * IE11: Fixed degree programme selector (HUB-324)
 * User groups for themes and instructions (HUB-318)
+* Autoselect user group tab (HUB-320)
 
 
 ## 1.18

--- a/config/sync/core.entity_form_display.taxonomy_term.degree_programme.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.degree_programme.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.degree_programme.field_code
     - field.field.taxonomy_term.degree_programme.field_degree_programme_type
+    - field.field.taxonomy_term.degree_programme.field_user_group
     - taxonomy.vocabulary.degree_programme
   module:
     - path
@@ -32,6 +33,12 @@ content:
     region: content
   field_degree_programme_type:
     weight: 31
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_user_group:
+    weight: 33
     settings: {  }
     third_party_settings: {  }
     type: options_select

--- a/config/sync/core.entity_view_display.taxonomy_term.degree_programme.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.degree_programme.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.degree_programme.field_code
     - field.field.taxonomy_term.degree_programme.field_degree_programme_type
+    - field.field.taxonomy_term.degree_programme.field_user_group
     - taxonomy.vocabulary.degree_programme
   module:
     - options
@@ -31,6 +32,13 @@ content:
     region: content
   field_degree_programme_type:
     weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_user_group:
+    weight: 12
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/field.field.taxonomy_term.degree_programme.field_user_group.yml
+++ b/config/sync/field.field.taxonomy_term.degree_programme.field_user_group.yml
@@ -1,0 +1,21 @@
+uuid: e39a41d8-1f6b-48bd-ae8e-3ad76092e25e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_user_group
+    - taxonomy.vocabulary.degree_programme
+  module:
+    - options
+id: taxonomy_term.degree_programme.field_user_group
+field_name: field_user_group
+entity_type: taxonomy_term
+bundle: degree_programme
+label: 'User group'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.taxonomy_term.field_user_group.yml
+++ b/config/sync/field.storage.taxonomy_term.field_user_group.yml
@@ -1,0 +1,30 @@
+uuid: 48ebec8d-0d45-4dc2-91c5-b9bd1e2a1b89
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - taxonomy
+id: taxonomy_term.field_user_group
+field_name: field_user_group
+entity_type: taxonomy_term
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: degree_students
+      label: 'Degree Students'
+    -
+      value: doctoral_candidates
+      label: 'Doctoral Candidates'
+    -
+      value: specialist_training
+      label: 'Specialist Training'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/fi/field.storage.taxonomy_term.field_user_group.yml
+++ b/config/sync/language/fi/field.storage.taxonomy_term.field_user_group.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: Perustutkinto-opiskelijat
+    -
+      label: Tohtorikoulutettavat
+    -
+      label: 'Ammatillinen jatkokoulutus'

--- a/config/sync/language/sv/field.storage.taxonomy_term.field_user_group.yml
+++ b/config/sync/language/sv/field.storage.taxonomy_term.field_user_group.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: Grundexamensstuderande
+    -
+      label: Doktorander
+    -
+      label: 'Yrkesinriktad påbyggnadsutbildning'

--- a/modules/uhsg_active_degree_programme/src/ActiveDegreeProgrammeService.php
+++ b/modules/uhsg_active_degree_programme/src/ActiveDegreeProgrammeService.php
@@ -145,6 +145,16 @@ class ActiveDegreeProgrammeService {
   }
 
   /**
+   * Return the user group of the active degree programme.
+   * @return string|null
+   */
+  public function getUserGroup() {
+    $term = $this->getTerm();
+
+    return $term ? $term->get('field_user_group')->getString() : NULL;
+  }
+
+  /**
    * Tries to get term ID from request.
    * @return string|null
    *   Returns an term ID or NULL, when not found.

--- a/modules/uhsg_active_degree_programme/uhsg_active_degree_programme.module
+++ b/modules/uhsg_active_degree_programme/uhsg_active_degree_programme.module
@@ -5,16 +5,22 @@
  * Contains uhsg_active_degree_programme.module.
  */
 
+use Drupal\uhsg_active_degree_programme\ActiveDegreeProgrammeService;
+
 /**
  * Implements hook_page_attachments().
  *
  * Adds a shortlink to current page with degree programme to HTML head section.
  * If no degree programme is selected, omit the degree programme parameter, but
  * still provide the full short URL.
+ *
+ * Adds degree programme user group to Drupal settings.
  */
 function uhsg_active_degree_programme_page_attachments(array &$page) {
+  /** @var $activeDegreeProgrammeService ActiveDegreeProgrammeService */
   $activeDegreeProgrammeService = \Drupal::service('uhsg_active_degree_programme.active_degree_programme');
   $degreeProgrammeCode = $activeDegreeProgrammeService->getCode();
+  $degreeProgrammeUserGroup = $activeDegreeProgrammeService->getUserGroup();
   $baseUrl = \Drupal\Core\Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
   $path = \Drupal\Core\Url::fromRoute('<current>')->getInternalPath();
   $href = $degreeProgrammeCode ? "$baseUrl/$path?degree_programme_code=$degreeProgrammeCode" : "$baseUrl/$path";
@@ -27,5 +33,6 @@ function uhsg_active_degree_programme_page_attachments(array &$page) {
     ],
   ];
   $page['#attached']['html_head'][] = [$shortlinkTag, 'description'];
+  $page['#attached']['drupalSettings']['uhsg_active_degree_programme']['userGroup'] = $degreeProgrammeUserGroup;
   $page['#cache']['contexts'][] = 'active_degree_programme';
 }

--- a/modules/uhsg_themes/js/autoselectUserGroupTab.js
+++ b/modules/uhsg_themes/js/autoselectUserGroupTab.js
@@ -1,0 +1,15 @@
+(function ($) {
+  'use strict';
+  Drupal.behaviors.autoselectUserGroupTab = {
+    attach: function (context, settings) {
+      $(window).on('load', function () {
+        var userGroup = settings.uhsg_active_degree_programme.userGroup;
+
+        if (userGroup) {
+          var userGroupTabSelector = '#block-themesperusergroup a[href="#' + userGroup + '"]';
+          $(userGroupTabSelector).click();
+        }
+      });
+    }
+  };
+}(jQuery));

--- a/modules/uhsg_themes/uhsg_themes.libraries.yml
+++ b/modules/uhsg_themes/uhsg_themes.libraries.yml
@@ -11,3 +11,10 @@ theme_sort:
     - core/jquery
     - core/jquery.once
     - core/modernizr
+
+autoselect_user_group_tab:
+  version: 1.x
+  js:
+    js/autoselectUserGroupTab.js: {}
+  dependencies:
+    - core/jquery

--- a/modules/uhsg_themes/uhsg_themes.module
+++ b/modules/uhsg_themes/uhsg_themes.module
@@ -13,6 +13,7 @@ function uhsg_themes_preprocess_views_view(&$variables) {
   if ($variables['view']->id() == 'themes') {
     $variables['#attached']['library'][] = 'uhsg_themes/sortable';
     $variables['#attached']['library'][] = 'uhsg_themes/theme_sort';
+    $variables['#attached']['library'][] = 'uhsg_themes/autoselect_user_group_tab';
   }
 }
 


### PR DESCRIPTION
# Autoselect user group tab

Automatically selects a user group tab on the front page based on the user group of the active degree programme.

## Testing

- Set user groups for some degree programmes.
- On the front page, change degree programmes and see that the matching tab is selected.
- Degree programmes do not need to have a user group. In these cases the first tab should be active.