### PR TITLE
Feature/hub 354 do not index courses embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.23-dev
 Release date: ??.??.????
 
+* Excluded courses embed content from the search (HUB-354)
+
 
 ## 1.22
 Release date: 25.09.2018

--- a/config/sync/search_api.index.content_index.yml
+++ b/config/sync/search_api.index.content_index.yml
@@ -108,8 +108,11 @@ field_settings:
 datasource_settings:
   'entity:node':
     bundles:
-      default: true
-      selected: {  }
+      default: false
+      selected:
+        - article
+        - news
+        - theme
     languages:
       default: true
       selected: {  }


### PR DESCRIPTION
Issue:

The current search indexes courses embed content. The search lists rendered entities. The courses embed will render the full embedded component. This breaks the search listing. Also, courses embed content is not curated and informational, so including it in the search results will not probably provide meaningful value for the end user.

Solution:

Exclude the courses embed content from indexing. Only index the selected content types to avoid future surprises.

After deployment:

It might be a good idea to re-index the search after deployment: `drush sapi-c && drush sapi-i` to get rid of the unwanted index content.