### PR TITLE
Feature/hub 373 theme related student content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: ??.??.????
 * Display only the login/logout main menu item on teacher domain (HUB-397)
 * Display general office hours grouped by language (HUB-362).
 * Do not display news blocks on teacher domain frontpage (HUB-392)
+* Support for referring to student articles and themes from the teacher domain (HUB-373)
 
 
 ## 1.26

--- a/config/sync/core.entity_form_display.node.theme.default.yml
+++ b/config/sync/core.entity_form_display.node.theme.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.theme.field_domain_source
     - field.field.node.theme.field_theme_articles
     - field.field.node.theme.field_theme_faq
+    - field.field.node.theme.field_theme_related
     - field.field.node.theme.field_theme_section
     - field.field.node.theme.field_theme_teaser_image
     - field.field.node.theme.field_user_group
@@ -57,6 +58,15 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
     third_party_settings: {  }
+    region: content
+  field_theme_related:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_theme_section:
     type: entity_reference_paragraphs

--- a/config/sync/core.entity_form_display.node.theme.default.yml
+++ b/config/sync/core.entity_form_display.node.theme.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.theme.body
     - field.field.node.theme.field_domain_source
     - field.field.node.theme.field_theme_articles
+    - field.field.node.theme.field_theme_domain
     - field.field.node.theme.field_theme_faq
     - field.field.node.theme.field_theme_related
     - field.field.node.theme.field_theme_section
@@ -60,7 +61,7 @@ content:
     third_party_settings: {  }
     region: content
   field_theme_related:
-    weight: 26
+    weight: 15
     settings:
       match_operator: CONTAINS
       size: 60
@@ -152,3 +153,4 @@ content:
     region: content
 hidden:
   field_domain_source: true
+  field_theme_domain: true

--- a/config/sync/core.entity_view_display.node.theme.default.yml
+++ b/config/sync/core.entity_view_display.node.theme.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.theme.body
     - field.field.node.theme.field_domain_source
     - field.field.node.theme.field_theme_articles
+    - field.field.node.theme.field_theme_domain
     - field.field.node.theme.field_theme_faq
     - field.field.node.theme.field_theme_related
     - field.field.node.theme.field_theme_section
@@ -71,6 +72,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_domain_source: true
+  field_theme_domain: true
   field_theme_teaser_image: true
   field_user_group: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.theme.default.yml
+++ b/config/sync/core.entity_view_display.node.theme.default.yml
@@ -4,8 +4,10 @@ status: true
 dependencies:
   config:
     - field.field.node.theme.body
+    - field.field.node.theme.field_domain_source
     - field.field.node.theme.field_theme_articles
     - field.field.node.theme.field_theme_faq
+    - field.field.node.theme.field_theme_related
     - field.field.node.theme.field_theme_section
     - field.field.node.theme.field_theme_teaser_image
     - field.field.node.theme.field_user_group
@@ -44,6 +46,15 @@ content:
       link: ''
     third_party_settings: {  }
     region: content
+  field_theme_related:
+    weight: 5
+    label: above
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
   field_theme_section:
     type: entity_reference_revisions_entity_view
     weight: 3
@@ -59,6 +70,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_domain_source: true
   field_theme_teaser_image: true
   field_user_group: true
   langcode: true

--- a/config/sync/field.field.node.theme.field_theme_domain.yml
+++ b/config/sync/field.field.node.theme.field_theme_domain.yml
@@ -1,0 +1,25 @@
+uuid: 28314d9b-e2d3-4ad0-8a30-1c3561e65fa9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_theme_domain
+    - node.type.theme
+id: node.theme.field_theme_domain
+field_name: field_theme_domain
+entity_type: node
+bundle: theme
+label: Domain
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:domain'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: weight
+      direction: ASC
+field_type: entity_reference

--- a/config/sync/field.field.node.theme.field_theme_related.yml
+++ b/config/sync/field.field.node.theme.field_theme_related.yml
@@ -19,7 +19,7 @@ settings:
   handler: views
   handler_settings:
     view:
-      view_name: articles_from_instructions_for_students
+      view_name: articles_and_themes_from_instructions_for_students
       display_name: entity_reference_1
       arguments: {  }
 field_type: entity_reference

--- a/config/sync/field.field.node.theme.field_theme_related.yml
+++ b/config/sync/field.field.node.theme.field_theme_related.yml
@@ -1,0 +1,25 @@
+uuid: a195d478-c2e1-46b5-a3dc-ae21e3d01758
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_theme_related
+    - node.type.theme
+id: node.theme.field_theme_related
+field_name: field_theme_related
+entity_type: node
+bundle: theme
+label: 'See also the Instructions for Students'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: articles_from_instructions_for_students
+      display_name: entity_reference_1
+      arguments: {  }
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_theme_domain.yml
+++ b/config/sync/field.storage.node.field_theme_domain.yml
@@ -1,0 +1,20 @@
+uuid: bd007176-8bb2-4448-acd6-1e2850e3ee13
+langcode: en
+status: true
+dependencies:
+  module:
+    - domain
+    - node
+id: node.field_theme_domain
+field_name: field_theme_domain
+entity_type: node
+type: entity_reference
+settings:
+  target_type: domain
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_theme_related.yml
+++ b/config/sync/field.storage.node.field_theme_related.yml
@@ -1,0 +1,19 @@
+uuid: 9573efd7-0a3a-4fd8-ab37-a6e8b6e6e298
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_theme_related
+field_name: field_theme_related
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/fi/field.field.node.theme.field_theme_related.yml
+++ b/config/sync/language/fi/field.field.node.theme.field_theme_related.yml
@@ -1,0 +1,1 @@
+label: 'Katso myös opiskelijan ohjeet'

--- a/config/sync/language/sv/field.field.node.theme.field_theme_related.yml
+++ b/config/sync/language/sv/field.field.node.theme.field_theme_related.yml
@@ -1,0 +1,1 @@
+label: 'Se även Instruktioner för studerande'

--- a/config/sync/views.view.articles_and_themes_from_instructions_for_students.yml
+++ b/config/sync/views.view.articles_and_themes_from_instructions_for_students.yml
@@ -1,0 +1,314 @@
+uuid: 9e0ea931-689f-4936-a1eb-7ee9a6feb2d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+    - node.type.theme
+  module:
+    - node
+    - user
+id: articles_and_themes_from_instructions_for_students
+label: 'Articles and themes from Instructions for students'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            article: article
+            theme: theme
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          order: ASC
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        field_article_domain_target_id:
+          id: field_article_domain_target_id
+          table: node__field_article_domain
+          field: field_article_domain_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: guide_student_helsinki_fi
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          plugin_id: string
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.articles_and_themes_from_instructions_for_students.yml
+++ b/config/sync/views.view.articles_and_themes_from_instructions_for_students.yml
@@ -221,6 +221,80 @@ display:
           entity_type: node
           entity_field: langcode
           plugin_id: language
+        field_article_domain_target_id:
+          id: field_article_domain_target_id
+          table: node__field_article_domain
+          field: field_article_domain_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: guide_student_helsinki_fi
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_theme_domain_target_id:
+          id: field_theme_domain_target_id
+          table: node__field_theme_domain
+          field: field_theme_domain_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: guide_student_helsinki_fi
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts:
         title:
           id: title
@@ -240,53 +314,18 @@ display:
       footer: {  }
       empty: {  }
       relationships: {  }
-      arguments:
-        field_article_domain_target_id:
-          id: field_article_domain_target_id
-          table: node__field_article_domain
-          field: field_article_domain_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: guide_student_helsinki_fi
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: false
-          plugin_id: string
+      arguments: {  }
       display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -308,7 +347,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.articles_from_instructions_for_students.yml
+++ b/config/sync/views.view.articles_from_instructions_for_students.yml
@@ -188,6 +188,43 @@ display:
           entity_type: node
           entity_field: langcode
           plugin_id: language
+        field_article_domain_target_id:
+          id: field_article_domain_target_id
+          table: node__field_article_domain
+          field: field_article_domain_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: guide_student_helsinki_fi
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts:
         title:
           id: title
@@ -207,53 +244,13 @@ display:
       footer: {  }
       empty: {  }
       relationships: {  }
-      arguments:
-        field_article_domain_target_id:
-          id: field_article_domain_target_id
-          table: node__field_article_domain
-          field: field_article_domain_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: guide_student_helsinki_fi
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: false
-          plugin_id: string
+      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -275,7 +272,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
+++ b/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
@@ -32,7 +32,7 @@ class LinkToInstructionsForStudents extends BlockBase {
     $url = $this->getUrl();
     $label = \Drupal::service('uhsg_domain.domain')->getStudentDomainLabel();
     $markup  = '<div class="item-list"><ul class="list-of-links"><li>';
-    $markup .= '<a href="' . $url . '" class="list-of-links__link button--action icon--arrow-offsite">';
+    $markup .= '<a href="' . $url . '" class="list-of-links__link button--action icon--external-link">';
     $markup .= $label;
     $markup .= '</a></li></ul></div>';
 

--- a/modules/uhsg_domain/uhsg_domain.drush.inc
+++ b/modules/uhsg_domain/uhsg_domain.drush.inc
@@ -11,6 +11,12 @@ function uhsg_domain_drush_command() {
       'limit' => 'The max number of articles to process.',
     ],
  ];
+  $items['uhsg-assign-theme-domains'] = [
+   'description' => 'Assign domains for published themes.',
+   'arguments' => [
+      'limit' => 'The max number of themes to process.',
+    ],
+ ];
  return $items;
 }
 
@@ -19,6 +25,21 @@ function drush_uhsg_domain_uhsg_assign_article_domains($limit = 100) {
     ->condition('type', 'article')
     ->condition('status', 1)
     ->notExists('field_article_domain')
+    ->range(0, $limit)
+    ->execute();
+
+  $nodes = \Drupal\node\Entity\Node::loadMultiple($nids);
+
+  foreach ($nodes as $node) {
+    $node->save();
+  }
+}
+
+function drush_uhsg_domain_uhsg_assign_theme_domains($limit = 100) {
+  $nids = \Drupal::entityQuery('node')
+    ->condition('type', 'theme')
+    ->condition('status', 1)
+    ->notExists('field_theme_domain')
     ->range(0, $limit)
     ->execute();
 

--- a/modules/uhsg_domain/uhsg_domain.module
+++ b/modules/uhsg_domain/uhsg_domain.module
@@ -30,8 +30,8 @@ function uhsg_domain_help($route_name, RouteMatchInterface $route_match) {
  */
 function uhsg_domain_entity_field_access($operation, \Drupal\Core\Field\FieldDefinitionInterface $field_definition, \Drupal\Core\Session\AccountInterface $account, \Drupal\Core\Field\FieldItemListInterface $items = NULL) {
 
-  // Related articles: Deny for other than Instructions for teaching.
-  return $field_definition->getName() == 'field_article_related' && !\Drupal::service('uhsg_domain.domain')->isTeachingDomain()
+  // Related content: Deny for other than Instructions for teaching.
+  return in_array($field_definition->getName(), ['field_article_related', 'field_theme_related']) && !\Drupal::service('uhsg_domain.domain')->isTeachingDomain()
     ? AccessResult::forbidden()
     : AccessResult::neutral();
 }

--- a/modules/uhsg_domain/uhsg_domain.module
+++ b/modules/uhsg_domain/uhsg_domain.module
@@ -45,9 +45,16 @@ function uhsg_domain_entity_field_access($operation, \Drupal\Core\Field\FieldDef
  * the user group is teachers, student domain for other user groups.
  */
 function uhsg_domain_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
-  if ($entity instanceof \Drupal\node\Entity\Node && $entity->getType() == 'article') {
+  if ($entity instanceof \Drupal\node\Entity\Node && in_array($entity->getType(), ['article', 'theme'])) {
     $domain_id = $entity->field_user_group->value == 'teachers' ? DomainService::TEACHING_DOMAIN_ID : DomainService::STUDENT_DOMAIN_ID;
-    $entity->field_article_domain = $domain_id;
+
+    if ($entity->getType() == 'article') {
+      $entity->field_article_domain = $domain_id;
+    }
+    else {
+      $entity->field_theme_domain = $domain_id;
+    }
+
     // TODO: Set domain source. Both domains need to be accessible for this to
     // work, since the links will be rewritten to point to one of the domains.
     //$entity->field_domain_source = $domain_id;

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8490,6 +8490,17 @@ li.avatar.avatar--default img {
   padding: 1em 0 .5em;
 }
 
+.article-related .box-story--topical.theme-plain .box-story__link-wrapper:after {
+  display: inline-block;
+  font-family: "hy-icons";
+  font-style: normal;
+  font-weight: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: bottom;
+  content: "";
+}
+
 #block-breadcrumbs {
   padding-top: 1.5em;
 }

--- a/themes/uhsg_theme/sass/components/_box_story.scss
+++ b/themes/uhsg_theme/sass/components/_box_story.scss
@@ -8,3 +8,11 @@
   border-bottom: 1px solid #f8f8f8;
   padding: 1em 0 .5em;
 }
+
+.article-related {
+  .box-story--topical.theme-plain {
+    .box-story__link-wrapper:after {
+      @include icon($icon-external-link);
+    }
+  }
+}

--- a/themes/uhsg_theme/templates/node/node--theme--full.html.twig
+++ b/themes/uhsg_theme/templates/node/node--theme--full.html.twig
@@ -84,13 +84,23 @@
   ]
 %}
 
+{% set related_content = create_attribute() %}
+
+{%
+  set related_content_classes = [
+    'container',
+    'tube',
+    'article-related'
+  ]
+%}
+
 <article {{ attributes.addClass(node_classes) }}>
   <div{{ content_attributes.addClass(container_classes) }}>
     <div class="col-container">
       <div class="col-main">
         <h1> {{ label }} </h1>
         {{ degree_programme_switcher }}
-        {{ content|without('field_theme_articles', 'field_theme_faq', 'field_theme_section') }}
+        {{ content|without('field_theme_articles', 'field_theme_faq', 'field_theme_section', 'field_theme_related') }}
       </div>
       {% if link_to_instructions_for_students %}
         <div class="col-right">
@@ -110,4 +120,9 @@
       </div>
     {% endif %}
   </div>
+  {% if content.field_theme_related %}
+    <div{{ related_content.addClass(related_content_classes) }}>
+      {{ content.field_theme_related }}
+    </div>
+  {% endif %}
 </article>

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -184,6 +184,11 @@ function uhsg_theme_preprocess_field(array &$variables, $hook) {
       $variables['description'] = t('You will find related content for students on the Instructions for Students Service.');
       break;
 
+    case 'field_theme_related':
+      $variables['attributes']['class'][] = 'grid-container tube--large';
+      $variables['description'] = t('You will find related content for students on the Instructions for Students Service.');
+      break;
+
     case 'body':
     case 'field_paragraph_body':
       $variables['attributes']['class'][] = 'textarea';


### PR DESCRIPTION
# Theme page: Related (student domain) content

When in teaching domain:

- Adds support for manually referring to articles and/or themes in the student domain from a theme.
- Displays the referred articles/themes on theme page.

## Other related updates

- Using a new external link icon that better matches the planned concept (previously using an offsite icon). Also updated for the "global" right column external link for consistency.

## Manual steps

- After deployment and configuration import, run `drush uhsg-assign-theme-domains` once to initially assign theme domains (once should be enough, since there should be less than 100 themes). From now on, the domains are assigned on theme saves (based on the selected user group).