### PR TITLE
Feature/hub 400 hyphenation on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: ??.??.????
 * Display only the login/logout main menu item on teacher domain (HUB-397)
 * Display general office hours grouped by language (HUB-362).
 * Do not display news blocks on teacher domain frontpage (HUB-392)
+* IE11: Fixed overflowing news and theme titles (HUB-400, HUB-404)
 
 
 ## 1.26

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8490,6 +8490,10 @@ li.avatar.avatar--default img {
   padding: 1em 0 .5em;
 }
 
+.box-story__title span {
+  width: 100%;
+}
+
 #block-breadcrumbs {
   padding-top: 1.5em;
 }
@@ -9437,6 +9441,7 @@ h1, h2, h3, h4, legend, .logo-block__content .logo-block__sitename,
   letter-spacing: -0.05em;
   line-height: 1.2em;
   font-weight: 700;
+  width: 100%;
 }
 
 .theme--box .theme__link-wrapper {
@@ -9495,6 +9500,7 @@ h1, h2, h3, h4, legend, .logo-block__content .logo-block__sitename,
   text-transform: uppercase;
   line-height: 1.2em;
   font-weight: 700;
+  width: 100%;
 }
 
 .theme--flat-box .theme__link-wrapper {

--- a/themes/uhsg_theme/sass/components/_box_story.scss
+++ b/themes/uhsg_theme/sass/components/_box_story.scss
@@ -8,3 +8,10 @@
   border-bottom: 1px solid #f8f8f8;
   padding: 1em 0 .5em;
 }
+
+// IE11: Define width to avoid overflowing titles.
+.box-story__title {
+  span {
+    width: 100%;
+  }
+}

--- a/themes/uhsg_theme/sass/components/_theme.scss
+++ b/themes/uhsg_theme/sass/components/_theme.scss
@@ -17,6 +17,8 @@
     letter-spacing: -0.05em;
     line-height: 1.2em;
     font-weight: 700;
+    // IE11: Define width to avoid overflowing titles.
+    width: 100%;
   }
 
   .theme__link-wrapper {
@@ -64,6 +66,8 @@
     text-transform: uppercase;
     line-height: 1.2em;
     font-weight: 700;
+    // IE11: Define width to avoid overflowing titles.
+    width: 100%;
   }
 
   .theme__link-wrapper {


### PR DESCRIPTION
- Fixes overflowing news and theme titles.
- Does not affect hyphenation, since that is browser-dependent functionality.
- Checked that the system has appropriate configs for hyphenation (html lang and css style rules).