### PR TITLE
Feature/hub 375 domain specific search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release date: ??.??.????
 * Do not display news blocks on teacher domain frontpage (HUB-392)
 * IE11: Fixed overflowing news and theme titles (HUB-400, HUB-404)
 * Support for referring to student articles and themes from the teacher domain (HUB-373)
+* Domain-specific search results (HUB-375)
 
 
 ## 1.26

--- a/config/sync/search_api.index.content_index.yml
+++ b/config/sync/search_api.index.content_index.yml
@@ -12,6 +12,8 @@ dependencies:
     - field.storage.node.field_theme_faq
     - field.storage.paragraph.field_accordion_title
     - field.storage.paragraph.field_accordion_body
+    - field.storage.node.field_article_domain
+    - field.storage.node.field_theme_domain
     - search_api.server.student_guide
   module:
     - paragraphs
@@ -105,6 +107,22 @@ field_settings:
         - field.storage.paragraph.field_accordion_body
       module:
         - paragraphs
+  field_article_domain:
+    label: 'Article domain'
+    datasource_id: 'entity:node'
+    property_path: field_article_domain
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_article_domain
+  field_theme_domain:
+    label: 'Theme domain'
+    datasource_id: 'entity:node'
+    property_path: field_theme_domain
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_theme_domain
 datasource_settings:
   'entity:node':
     bundles:

--- a/modules/uhsg_search/uhsg_search.module
+++ b/modules/uhsg_search/uhsg_search.module
@@ -1,11 +1,13 @@
 <?php
 
-/**
- * Implements hook_form_FORM_ID_alter().
- */use Drupal\search_api\Query\QueryInterface;
+use Drupal\search_api\Query\QueryInterface;
+use Solarium\QueryType\Select\Query\FilterQuery;
 use Solarium\QueryType\Select\Query\Query;
 use Drupal\Core\Form\FormStateInterface;
 
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function uhsg_search_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (\Drupal::service('path.matcher')->isFrontPage()) {
     $form['#attached']['library'][] = 'uhsg_search/uhsg-search';
@@ -61,6 +63,7 @@ function uhsg_search_article_is_degree_programme_specific($node) {
  */
 function uhsg_search_search_api_solr_query_alter(Query $solarium_query, QueryInterface $query) {
   uhsg_search_wildcard_query($solarium_query);
+  uhsg_search_domain_filter($solarium_query);
 }
 
 /**
@@ -88,4 +91,19 @@ function uhsg_search_wildcard_query(Query $solarium_query) {
     // Override query.
     $solarium_query->setQuery($query);
   }
+}
+
+/**
+ * Add active domain filtering to search query for articles and themes. News do
+ * not have domain associated with them. Allow them in the results by adding a
+ * type filter as the last OR filter.
+ *
+ * @param \Solarium\QueryType\Select\Query\Query $solarium_query
+ */
+function uhsg_search_domain_filter(Query $solarium_query) {
+  $active_domain_id = \Drupal::service('uhsg_domain.domain')->getActiveDomainId();
+  $domain_filter_query = (new FilterQuery())
+    ->setKey('domain')
+    ->setQuery("(ss_field_theme_domain:$active_domain_id OR ss_field_article_domain:$active_domain_id OR ss_type:news)");
+  $solarium_query->addFilterQuery($domain_filter_query);
 }


### PR DESCRIPTION
# Domain-specific search results

Adds active domain filtering to search query for articles and themes. News do not have domain associated with them. Allow them in the results by adding a type filter as the last OR filter.

## Testing

- Make sure that articles and themes have the domain assigned. If not, run both `drush uhsg-assign-article-domains` and `uhsg-assign-theme-domains`.

- After config import, run indexing (`drush sapi-i`) to index the domain information.