### PR TITLE
HUB-357: Open summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: ??.??.????
 * Translate "User group" (HUB-393)
 * Include only the titles and the link in news email (HUB-425)
 * Exclude study track code from the Eduviewer embed (HUB-433)
+* Show summary field always when maintaining bulletins (HUB-357)
 
 
 ## 1.30

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
         "drush/drush": "8.1.15",
         "drupal/view_unpublished": "1.x-dev#aea97e837ea9b1b5522f710239cf7d1cc16f2306",
         "UH-StudentServices/uh_courses_embed": "dev-drupal8#af738078abebb19534fd87bb7669e4bd1ae66e5b[F",
-        "drupal/domain": "^1.0-alpha14"
+        "drupal/domain": "^1.0-alpha14",
+        "drupal/text_summary_options": "^1.0"
     },
     "repositories": {
         "0": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,19 +1,17 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1dd4b2fa80cca79b9186abe001c8f87e",
+    "content-hash": "a5c512115a9e7844ee743f723fcad437",
     "packages": [
         {
             "name": "RubaXa/Sortable",
             "version": "v1.4.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/RubaXa/Sortable/archive/1.4.0.zip",
-                "reference": null,
-                "shasum": null
+                "url": "https://github.com/RubaXa/Sortable/archive/1.4.0.zip"
             },
             "type": "drupal-library"
         },
@@ -3438,6 +3436,57 @@
                 "source": "http://git.drupal.org/project/search_api_solr.git",
                 "issues": "https://www.drupal.org/project/issues/search_api_solr",
                 "irc": "irc://irc.freenode.org/drupal-search-api"
+            }
+        },
+        {
+            "name": "drupal/text_summary_options",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/text_summary_options",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/text_summary_options-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "dcd1b98738ba7ca7768155d5f3c2e2bc7258d64f"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1543787580",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "kim.pepper",
+                    "homepage": "https://www.drupal.org/user/370574"
+                },
+                {
+                    "name": "rcodina",
+                    "homepage": "https://www.drupal.org/user/2635031"
+                }
+            ],
+            "description": "Provide additional options for Long text with summary widget",
+            "homepage": "https://www.drupal.org/project/text_summary_options",
+            "support": {
+                "source": "http://cgit.drupalcode.org/text_summary_options"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -68,6 +68,7 @@ module:
   system: 0
   taxonomy: 0
   text: 0
+  text_summary_options: 0
   token: 0
   toolbar: 0
   uh_courses_embed: 0

--- a/config/sync/field.field.node.news.body.yml
+++ b/config/sync/field.field.node.news.body.yml
@@ -7,6 +7,11 @@ dependencies:
     - node.type.news
   module:
     - text
+    - text_summary_options
+third_party_settings:
+  text_summary_options:
+    show_summary: 1
+    required_summary: 0
 id: node.news.body
 field_name: body
 entity_type: node


### PR DESCRIPTION
### Ongelma

Tiedotteiden yhteenvetoa ei aina muisteta kirjoittaa kun kenttä pitäisi muistaa itse klikata auki. Ilman yhteenvetoa tiedotenäkymä venyy pitkäksi.

### Ratkaisu vaihtoehdot

Ratkaisuksi pyritään käyttämään valmista yhteisömoduulia.

#### Open Summary -moduuli

Moduuli ei ole virallisesti merkitty vakaaksi moduuliksi. Se on julkaistu vuonna 2017 Huhtikuussa ilmeisesti ajatuksella "käyttäkää jos sattuu olemaan hyötyä jollekin muulle". Projektin ylläpitäjä on merkinnyt sen minimaalisesti ylläpidettäväksi. Virallista julkaisuversiota ei ole tehty, jaossa on vain kehitysverio.

Moduulille on kirjoitettu vain yksi *issue*, joka liittyi lähinnä koodaus standardeihin (minor) ja sekin oli korjattu vuosi sitten.

Haluttu toiminto on sinänsä yksinkertainen, joten moduuli tuskin on mitenkään suuri tai sen lähdekoodi eroaisi omasta räätälöidystä ratkaisustakaan.

Moduulia käyttää 7 sivustoa (299 latausta).

Moduuli on minimalistinen ja toiminto perustuu käytännössä siihen, että se injektoi nykyisiin tekstikenttiin asetuksen, joka voidaan laittaa päällee ja jonka perusteella se estää JS toiminnallisuutta.

#### Summary Options -moduuli

Moduuli on selkeäst laajemmassa käytössä kuin *Open Summary* -moduuli. Moduulista on vakaa versio julkaistu 2.12.2018 ja on ylläpitotilaksi merkitty "korjauksia pelkästään".

Moduulilla on kymmenkunta *issueta* ja niistä kolme on vielä auki. Kaikki kolme ovat prioteetillä *normaali*.

Summary Options tuo toisenkin toiminnallisuuden rinnalle, siinä voidaan määrittää yhteenveto kenttä myös pakolliseksi kentäksi.

Summary Options moduuli toimii samalla tavalla kuin *Open Summary*. Jos jättää tuon "pakollisuus" toiminnallisuuden pois, niin se toimii lähes samoin, mutta ainoana erona on se, että *Summary Options* poistaa kaikki JS liitännäiset kyseisestä elementistä, siinä missä *Open Summary* taas poistaa tietyn JS liitännäisen.

**Open Summary**

```php
      $i = array_search('text/drupal.text', $element['summary']['#attached']['library']);
      if ($i !== FALSE) {
        unset($element['summary']['#attached']['library'][$i]);
      }
```

**Summary Options**

```php
    if ($show_summary_setting) {
      unset($element['summary']['#attached']);
    }
```

Etsin meidän koodista muutamilla hakusanoilla, onko meillä koodia, jossa liitetään elementtiin lisää JS liitännäisiä, mutta ei tuottanut tuloksia. Näin voidaan olettaa, että ainakaan meidän räätälöidyt toiminnallisuudet eivät poistu *Summary Options* moduulin myötä.

Moduulia on kehitetty vuodesta 2015 ja sitä käyttää ainakin 1000 sivustoa (11k latausta).

### Drupal ytimeen työstetään jo tätä toiminnallisuutta

Tämä tarve on tunnistettu ja sitä myös työstetään suoraan [ytimeen ominaisuudeksi](https://www.drupal.org/project/drupal/issues/1704864). Sen kehitys oli pysähtynyt kahdeksi vuodeksi, mutta sitä nyt vietiin eteenpäin hiljattain 6.3.2019.

#### Lopullinen ratkaisu

Päädyttiin ottamaan käyttöön *Summary Options* moduuli, koska se on lähes yhtä yksinkertainen kuin *Open Summary* ja sillä on vakaampi pohja yllädon kannalta.

Moduuli tiedostaa, että ominaisuutta työstetään suoraan ytimeen. Kun/jos tämä menee joskus läpi, niin voimme siirtyä käyttämään sitä suoraan ja poistaa moduuli.