### PR TITLE
HUB-358: Summary limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release date: ??.??.????
 * Exclude study track code from the Eduviewer embed (HUB-433)
 * Improve bulletin archive page (HUB-406)
 * Show summary field always when maintaining bulletins (HUB-357)
+* Limit summary field to 190 characters (HUB-358)
 
 
 ## 1.30

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "UH-StudentServices/uh_courses_embed": "dev-drupal8#af738078abebb19534fd87bb7669e4bd1ae66e5b[F",
         "drupal/domain": "^1.0-alpha14",
         "drupal/text_summary_options": "^1.0",
-        "drupal/maxlength": "^1.0@beta"
+        "drupal/maxlength": "1.x-dev#3235f5ca1a7532b29612b027f02f949bde2bbe5f"
     },
     "repositories": {
         "0": {

--- a/composer.json
+++ b/composer.json
@@ -133,6 +133,9 @@
             "drupal/google_analytics_reports": {
                 "2795115-6-and-2860399-1": "patches/google_analytics_reports.patch",
                 "2850463-2": "https://www.drupal.org/files/issues/error_when_saving-2850463-2.patch"
+            },
+            "drupal/maxlength": {
+                "2902083-2": "https://www.drupal.org/files/issues/translateable_help-2902083-2.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "drupal/view_unpublished": "1.x-dev#aea97e837ea9b1b5522f710239cf7d1cc16f2306",
         "UH-StudentServices/uh_courses_embed": "dev-drupal8#af738078abebb19534fd87bb7669e4bd1ae66e5b[F",
         "drupal/domain": "^1.0-alpha14",
-        "drupal/text_summary_options": "^1.0"
+        "drupal/text_summary_options": "^1.0",
+        "drupal/maxlength": "^1.0@beta"
     },
     "repositories": {
         "0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ba2213e5429315a95dae6837948b6b3",
+    "content-hash": "8aefa846ea7b0dcf81ecb7fbf713f1f7",
     "packages": [
         {
             "name": "RubaXa/Sortable",
@@ -2591,17 +2591,11 @@
         },
         {
             "name": "drupal/maxlength",
-            "version": "1.0.0-beta2",
+            "version": "dev-1.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/maxlength",
-                "reference": "8.x-1.0-beta2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/maxlength-8.x-1.0-beta2.zip",
-                "reference": "8.x-1.0-beta2",
-                "shasum": "27f7374e55ebdcc696d22d98be8cf4cf9bf58204"
+                "reference": "3235f5ca1a7532b29612b027f02f949bde2bbe5f"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -2612,11 +2606,11 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0-beta2",
-                    "datestamp": "1527856384",
+                    "version": "8.x-1.0-beta2+6-dev",
+                    "datestamp": "1535579880",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "message": "Dev releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -2694,7 +2688,8 @@
             "homepage": "https://www.drupal.org/project/maxlength",
             "support": {
                 "source": "http://cgit.drupalcode.org/maxlength"
-            }
+            },
+            "time": "2018-08-29T21:58:44+00:00"
         },
         {
             "name": "drupal/migrate_plus",
@@ -9335,7 +9330,7 @@
         "drupal/edit_own_user_account_permission": 20,
         "drupal/view_unpublished": 20,
         "uh-studentservices/uh_courses_embed": 20,
-        "drupal/maxlength": 10
+        "drupal/maxlength": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5c512115a9e7844ee743f723fcad437",
+    "content-hash": "8ba2213e5429315a95dae6837948b6b3",
     "packages": [
         {
             "name": "RubaXa/Sortable",
@@ -2587,6 +2587,113 @@
             ],
             "support": {
                 "source": "http://cgit.drupalcode.org/honeypot"
+            }
+        },
+        {
+            "name": "drupal/maxlength",
+            "version": "1.0.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/maxlength",
+                "reference": "8.x-1.0-beta2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/maxlength-8.x-1.0-beta2.zip",
+                "reference": "8.x-1.0-beta2",
+                "shasum": "27f7374e55ebdcc696d22d98be8cf4cf9bf58204"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-beta2",
+                    "datestamp": "1527856384",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Aron Novak",
+                    "homepage": "https://www.drupal.org/user/61864"
+                },
+                {
+                    "name": "Schnitzel",
+                    "homepage": "https://www.drupal.org/user/643820"
+                },
+                {
+                    "name": "a_c_m",
+                    "homepage": "https://www.drupal.org/user/195063"
+                },
+                {
+                    "name": "artur.thiessen",
+                    "homepage": "https://www.drupal.org/user/2390554"
+                },
+                {
+                    "name": "barneytech",
+                    "homepage": "https://www.drupal.org/user/669922"
+                },
+                {
+                    "name": "claudiu_cristea",
+                    "homepage": "https://www.drupal.org/user/2623935"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "derhasi",
+                    "homepage": "https://www.drupal.org/user/83474"
+                },
+                {
+                    "name": "frjo",
+                    "homepage": "https://www.drupal.org/user/5546"
+                },
+                {
+                    "name": "hefox",
+                    "homepage": "https://www.drupal.org/user/426416"
+                },
+                {
+                    "name": "jm.federico",
+                    "homepage": "https://www.drupal.org/user/509892"
+                },
+                {
+                    "name": "k4v",
+                    "homepage": "https://www.drupal.org/user/744246"
+                },
+                {
+                    "name": "mariano73",
+                    "homepage": "https://www.drupal.org/user/1324866"
+                },
+                {
+                    "name": "mariuss",
+                    "homepage": "https://www.drupal.org/user/28539"
+                },
+                {
+                    "name": "sanduhrs",
+                    "homepage": "https://www.drupal.org/user/28074"
+                },
+                {
+                    "name": "vasi1186",
+                    "homepage": "https://www.drupal.org/user/342104"
+                }
+            ],
+            "description": "Limit the number of characters in textfields and textareas and shows the amount of characters left.",
+            "homepage": "https://www.drupal.org/project/maxlength",
+            "support": {
+                "source": "http://cgit.drupalcode.org/maxlength"
             }
         },
         {
@@ -9227,7 +9334,8 @@
         "drupal/facets": 15,
         "drupal/edit_own_user_account_permission": 20,
         "drupal/view_unpublished": 20,
-        "uh-studentservices/uh_courses_embed": 20
+        "uh-studentservices/uh_courses_embed": 20,
+        "drupal/maxlength": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -30,9 +30,9 @@ content:
       summary_rows: 3
     third_party_settings:
       maxlength:
-        maxlength_js: 1000
+        maxlength_js: null
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_summary: 250
+        maxlength_js_summary: 190
         maxlength_js_label_summary: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
         maxlength_js_truncate_html: false

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - node.type.news
   module:
     - image
+    - maxlength
     - path
     - text
 id: node.news.default
@@ -25,9 +26,16 @@ content:
     weight: 8
     settings:
       rows: 9
-      summary_rows: 3
       placeholder: ''
-    third_party_settings: {  }
+      summary_rows: 3
+    third_party_settings:
+      maxlength:
+        maxlength_js: 1000
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_summary: 250
+        maxlength_js_label_summary: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
     region: content
   created:
     type: datetime_timestamp

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -39,6 +39,7 @@ module:
   language: 0
   link: 0
   locale: 0
+  maxlength: 0
   menu_ui: 0
   migrate: 0
   migrate_plus: 0


### PR DESCRIPTION
This change will bring new module "Maxlength" which is widely used in Drupal 7 sites, but it has an ported version to Drupal 8 too. Despite it's in beta2 phase, maintainer is recommending it for the use.

The module is not super big and not hooking into many things, so I consider this module safe from backend point of view. Only worrying part is the JS functionality, that's where most of the functionality is executed, but luckily we are trying to achieve here simple and not business critical things.

# Module's codereview
Module works basically as follows:
* I defines the standard help texts
* It hooks into element rendering adding JS attachments and CSS classes
* It specifies third party settings for widgets, these settings allows maintainer to specify which fields has maxlength functionality enabled. It has a service too that specifies which are configurable field elements.
* Triggering the maxlength functionality through widget altering hook
* The JS file itself that contains runs the functionality in frontend

This module does not bring any backend validation, but this is not a requirement for out case. Therefore limiting our text in frontend only is sufficient solution.

## Issues
The latest 1.0-beta2 had two issues that affected to us.

When specifying maximum length to summary, it doesn't trigger the functionality unless you specify maximum length to the main field too. This issue has been fixed in DEV, which is why we use the dev version.

The feedback text that tells you how many characters there are left, does not get translated correctly even the translation exists. This is resolved by using a patch from [a issue](https://www.drupal.org/project/maxlength/issues/2902083).