### PR TITLE
Feature/hub 461 improve accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Release date: ??.??.????
 
 * Add domain redirect support to article and theme forms (HUB-456)
+* Improve accessibility (HUB-461)
 
 
 ## 1.33

--- a/modules/uhsg_feedback/uhsg_feedback.module
+++ b/modules/uhsg_feedback/uhsg_feedback.module
@@ -61,7 +61,7 @@ function uhsg_feedback_mail_alter(&$message) {
  */
 function uhsg_feedback_form_alter(&$form, $form_state, $form_id) {
   if ($form_id == 'contact_message_feedback_form_form') {
-    $form['message']['widget'][0]['value']['#title_display'] = 'visually-hidden';
+    $form['message']['widget'][0]['value']['#title_display'] = 'invisible';
     $form['message']['widget'][0]['value']['#placeholder'] = t('Give feedback about the service...');
     $form['mail']['#required'] = FALSE;
     $form['actions']['preview']['#access'] = FALSE;

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -590,3 +590,29 @@ function _uhsg_theme_get_news_per_degree_programme() {
     ? \Drupal::entityTypeManager()->getViewBuilder('block')->view($news_per_degree_programme)
     : '';
 }
+
+/**
+ * Implements template_preprocess_textarea().
+ */
+function uhsg_theme_preprocess_textarea(&$variables) {
+  _uhsg_theme_add_element_title_as_aria_label_attribute($variables);
+}
+
+/**
+ * Implements template_preprocess_input().
+ */
+function uhsg_theme_preprocess_input(&$variables) {
+  _uhsg_theme_add_element_title_as_aria_label_attribute($variables);
+}
+
+/**
+ * Add element title (label) as aria-label attribute if the aria-label attribute
+ * or the aria-labelledby attribute does not exist.
+ */
+function _uhsg_theme_add_element_title_as_aria_label_attribute(&$variables) {
+  $element = $variables['element'];
+  $attributes =& $variables['attributes'];
+  if (!empty($element['#title']) && empty($attributes['aria-label']) && empty($attributes['aria-labelledby'])) {
+    $attributes['aria-label'] = strip_tags($element['#title']);
+  }
+}


### PR DESCRIPTION
- Add label to feedback form message field (had incorrect title visibility value that caused the label element to be missing completely).

- Textareas and inputs: Add element title (label) as `aria-label` attribute if the `aria-label` attribute or the `aria-labelledby` attribute does not exist. This should improve screen reader accessibility.