### PR TITLE
HUB-454: News for doctoral candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Release date: ??.??.????
 
 * Update university address (HUB-463)
+* Add user group to news (HUB-454)
 
 
 ## 1.34

--- a/config/sync/block.block.contactblock.yml
+++ b/config/sync/block.block.contactblock.yml
@@ -12,7 +12,7 @@ dependencies:
 id: contactblock
 theme: uhsg_theme
 region: after_content
-weight: -5
+weight: -9
 provider: null
 plugin: contact_block
 settings:

--- a/config/sync/block.block.generalnews.yml
+++ b/config/sync/block.block.generalnews.yml
@@ -10,7 +10,7 @@ dependencies:
 id: generalnews
 theme: uhsg_theme
 region: after_content
-weight: -10
+weight: -12
 provider: null
 plugin: general_news
 settings:

--- a/config/sync/block.block.newsperdegreeprogramme.yml
+++ b/config/sync/block.block.newsperdegreeprogramme.yml
@@ -10,7 +10,7 @@ dependencies:
 id: newsperdegreeprogramme
 theme: uhsg_theme
 region: after_content
-weight: -11
+weight: -8
 provider: null
 plugin: news_per_degree_programme
 settings:

--- a/config/sync/block.block.newsperdegreeprogramme_2.yml
+++ b/config/sync/block.block.newsperdegreeprogramme_2.yml
@@ -10,7 +10,7 @@ dependencies:
 id: newsperdegreeprogramme_2
 theme: uhsg_theme
 region: after_content
-weight: -9
+weight: -11
 provider: null
 plugin: general_news
 settings:

--- a/config/sync/block.block.newsperdoctoralprogramme.yml
+++ b/config/sync/block.block.newsperdoctoralprogramme.yml
@@ -1,0 +1,20 @@
+uuid: 7559c387-22d4-4bf9-a6a9-a27c3ba57121
+langcode: en
+status: false
+dependencies:
+  module:
+    - uhsg_news
+  theme:
+    - uhsg_theme
+id: newsperdoctoralprogramme
+theme: uhsg_theme
+region: after_content
+weight: -7
+provider: null
+plugin: news_per_doctoral_programme
+settings:
+  id: news_per_doctoral_programme
+  label: 'Notifications from your degree programme'
+  provider: uhsg_news
+  label_display: visible
+visibility: {  }

--- a/config/sync/block.block.themesperusergroup.yml
+++ b/config/sync/block.block.themesperusergroup.yml
@@ -10,7 +10,7 @@ dependencies:
 id: themesperusergroup
 theme: uhsg_theme
 region: after_content
-weight: -7
+weight: -10
 provider: null
 plugin: themes_per_user_group
 settings:

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -9,12 +9,14 @@ dependencies:
     - field.field.node.news.field_news_email
     - field.field.node.news.field_news_email_sent
     - field.field.node.news.field_news_image
+    - field.field.node.news.field_user_group
     - image.style.thumbnail
     - node.type.news
   module:
     - image
     - maxlength
     - path
+    - scheduler
     - text
 id: node.news.default
 targetEntityType: node
@@ -68,6 +70,12 @@ content:
     third_party_settings: {  }
     type: image_image
     region: content
+  field_user_group:
+    weight: 31
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   langcode:
     type: language_select
     weight: 1
@@ -86,6 +94,17 @@ content:
     settings:
       display_label: true
     weight: 5
+    third_party_settings: {  }
+    region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 20
+    settings: {  }
     third_party_settings: {  }
     region: content
   status:
@@ -124,6 +143,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   field_domain_source: true
   field_news_email_sent: true

--- a/config/sync/core.entity_view_display.node.news.default.yml
+++ b/config/sync/core.entity_view_display.node.news.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.news.field_news_email
     - field.field.node.news.field_news_email_sent
     - field.field.node.news.field_news_image
+    - field.field.node.news.field_user_group
     - image.style.image_full_width
     - node.type.news
   module:
@@ -48,5 +49,6 @@ hidden:
   field_domain_source: true
   field_news_email: true
   field_news_email_sent: true
+  field_user_group: true
   langcode: true
   links: true

--- a/config/sync/field.field.node.news.field_user_group.yml
+++ b/config/sync/field.field.node.news.field_user_group.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: news
 label: 'User group'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.news.field_user_group.yml
+++ b/config/sync/field.field.node.news.field_user_group.yml
@@ -1,0 +1,21 @@
+uuid: 61edb98c-0826-458e-addc-ba2d6bd03877
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_user_group
+    - node.type.news
+  module:
+    - options
+id: node.news.field_user_group
+field_name: field_user_group
+entity_type: node
+bundle: news
+label: 'User group'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/language/fi/block.block.newsperdoctoralprogramme.yml
+++ b/config/sync/language/fi/block.block.newsperdoctoralprogramme.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Koulutusohjelmasi tiedotteet'

--- a/config/sync/language/sv/block.block.newsperdoctoralprogramme.yml
+++ b/config/sync/language/sv/block.block.newsperdoctoralprogramme.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Meddelanden från ditt utbildningsprogram'

--- a/modules/uhsg_news/src/Plugin/Block/NewsPerDegreeProgramme.php
+++ b/modules/uhsg_news/src/Plugin/Block/NewsPerDegreeProgramme.php
@@ -16,13 +16,16 @@ class NewsPerDegreeProgramme extends NewsBlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    $activeDegreeProgrammeTermId = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getId();
+    $activeDegreeProgrammeTerm = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getTerm();
 
-    if (!$activeDegreeProgrammeTermId) {
-      return [];
+    $isDegreeStudentProgramme = $activeDegreeProgrammeTerm
+      && $activeDegreeProgrammeTerm->get('field_degree_programme_type')->value !== 'doctoral';
+
+    if ($isDegreeStudentProgramme) {
+      return $this->render(\Drupal::service('uhsg_news.news')->getProgrammeNewsNids());
     }
 
-    return $this->render(\Drupal::service('uhsg_news.news')->getProgrammeNewsNids());
+    return [];
   }
 
 }

--- a/modules/uhsg_news/src/Plugin/Block/NewsPerDoctoralProgramme.php
+++ b/modules/uhsg_news/src/Plugin/Block/NewsPerDoctoralProgramme.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\uhsg_news\Plugin\Block;
+
+/**
+ * Provides a 'news_per_doctoral_programme' block.
+ *
+ * @Block(
+ *  id = "news_per_doctoral_programme",
+ *  admin_label = @Translation("News per doctoral programme"),
+ * )
+ */
+class NewsPerDoctoralProgramme extends NewsBlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $activeDegreeProgrammeTerm = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getTerm();
+
+    if (!$activeDegreeProgrammeTerm) {
+      return [];
+    }
+
+    // Render the block if the active degree programme is a doctoral programme.
+    if ($activeDegreeProgrammeTerm->get('field_user_group')->value === 'doctoral_candidates') {
+      return $this->render(\Drupal::service('uhsg_news.news')->getProgrammeNewsNids());
+    }
+
+    return [];
+  }
+
+}

--- a/modules/uhsg_news/src/Plugin/Block/NewsPerDoctoralProgramme.php
+++ b/modules/uhsg_news/src/Plugin/Block/NewsPerDoctoralProgramme.php
@@ -18,12 +18,10 @@ class NewsPerDoctoralProgramme extends NewsBlockBase {
   public function build() {
     $activeDegreeProgrammeTerm = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getTerm();
 
-    if (!$activeDegreeProgrammeTerm) {
-      return [];
-    }
+    $isDoctoralProgramme = $activeDegreeProgrammeTerm
+      && $activeDegreeProgrammeTerm->get('field_degree_programme_type')->value === 'doctoral';
 
-    // Render the block if the active degree programme is a doctoral programme.
-    if ($activeDegreeProgrammeTerm->get('field_user_group')->value === 'doctoral_candidates') {
+    if ($isDoctoralProgramme) {
       return $this->render(\Drupal::service('uhsg_news.news')->getProgrammeNewsNids());
     }
 

--- a/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
+++ b/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
@@ -91,7 +91,14 @@
             {{ content['content']['degree_students'] }}
           </div>
           <div id="doctoral_candidates">
-            {{ block('title_block') }}
+            {{ news_per_doctoral_programme }}
+            {% block title_block_doctoral_news %}
+              {{ title_prefix }}
+              {% if label %}
+                <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+              {% endif %}
+              {{ title_suffix }}
+            {% endblock %}
             {{ content['content']['doctoral_candidates'] }}
           </div>
           <div id="specialist_training">

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -352,6 +352,7 @@ function uhsg_theme_preprocess_block(array &$variables) {
     case 'generalnews':
     case 'newsperdegreeprogramme':
     case 'newsperdegreeprogramme_2':
+    case 'newsperdoctoralprogramme':
       $variables['content_attributes']['class'][] = 'grid-container';
 
       // Truncate news headlines in browser, so that search engines can pick up
@@ -367,6 +368,7 @@ function uhsg_theme_preprocess_block(array &$variables) {
     case 'themesperusergroup':
       if (\Drupal::service('uhsg_domain.domain')->isStudentDomain()) {
         $variables['news_per_degree_programme'] = _uhsg_theme_get_news_per_degree_programme();
+        $variables['news_per_doctoral_programme'] = _uhsg_theme_get_news_per_doctoral_programme();
       }
       break;
   }
@@ -516,6 +518,7 @@ function uhsg_theme_theme_suggestions_block_alter(&$suggestions, $vars, $hook) {
     'generalnews',
     'newsperdegreeprogramme',
     'newsperdegreeprogramme_2',
+    'newsperdoctoralprogramme',
     'views_block__google_analytics_summary_top_searches_block',
   ];
 
@@ -588,6 +591,14 @@ function _uhsg_theme_get_news_per_degree_programme() {
 
   return $news_per_degree_programme
     ? \Drupal::entityTypeManager()->getViewBuilder('block')->view($news_per_degree_programme)
+    : '';
+}
+
+function _uhsg_theme_get_news_per_doctoral_programme() {
+  $news_per_doctoral_programme = Block::load('newsperdoctoralprogramme');
+
+  return $news_per_doctoral_programme
+    ? \Drupal::entityTypeManager()->getViewBuilder('block')->view($news_per_doctoral_programme)
     : '';
 }
 


### PR DESCRIPTION
# News for doctoral candidates

## Content editor

- Adds user group to news (optional field). Note that this field does not affect the functionality at the moment. It will be needed later on when providing news to external systems and when adding user group grouping to guide search results.

## Visitors

- Displays news under the "Doctoral Candidates" tab on the front page matching the active degree programme when the active degree programme is of type `doctoral`. Note that the news user group does not affect this functionality.

- Displays news under the "Degree Students" tab on the front page matching the active degree programme when the active degree programme _is not_ of type `doctoral`. This is to prevent doctoral programme specific news to be displayed as non-doctoral degree programme specific news. It is ok, for now, to display all other news under this tab. Note that the news user group does not affect this functionality.