### PR TITLE
Feature/hub 453 news api

### DIFF
--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -88,6 +88,17 @@ content:
     weight: 5
     third_party_settings: {  }
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     settings:
@@ -124,6 +135,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   field_domain_source: true
   field_news_email_sent: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -36,6 +36,7 @@ module:
   google_analytics: 0
   honeypot: 0
   image: 0
+  jsonapi: 0
   language: 0
   link: 0
   locale: 0

--- a/config/sync/jsonapi.settings.yml
+++ b/config/sync/jsonapi.settings.yml
@@ -1,0 +1,4 @@
+langcode: en
+read_only: true
+_core:
+  default_config_hash: p_qzzTwtOMiIPE7CyG0wD6M-UCpBp6Y5E4LhNCnCRpY


### PR DESCRIPTION
# News API

- Enables JSON:API module in read-only mode to provide access to all content.
- No extra configuration needed.