### PR TITLE
Feature/hub 476 do not attach obar library on admin ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* Do not attach Obar library on admin UI (HUB-476)
 
 
 ## 1.36

--- a/modules/uhsg_obar/uhsg_obar.module
+++ b/modules/uhsg_obar/uhsg_obar.module
@@ -49,7 +49,7 @@ function uhsg_obar_theme_suggestions_region_alter(&$suggestions, $variables, $ho
  * Implements hook_page_attachments_alter().
  */
 function uhsg_obar_page_attachments_alter(&$page) {
-  if (\Drupal::service('uhsg_domain.domain')->isStudentDomain()) {
+  if (!\Drupal::service('router.admin_context')->isAdminRoute() && \Drupal::service('uhsg_domain.domain')->isStudentDomain()) {
     $page['#attached']['drupalSettings']['uhsgObar']['obarBaseUrl'] = \Drupal::config('uhsg_obar.settings')->get('base_url');
     $page['#attached']['library'][] = 'uhsg_obar/uhsg_obar.obar';
   }

--- a/modules/uhsg_obar/uhsg_obar.module
+++ b/modules/uhsg_obar/uhsg_obar.module
@@ -26,7 +26,7 @@ function uhsg_obar_library_info_build() {
  * Implements hook_preprocess_hook().
  */
 function uhsg_obar_preprocess_region(&$variables) {
-  if ($variables['region'] == 'header' && \Drupal::service('uhsg_domain.domain')->isStudentDomain()) {
+  if ($variables['region'] == 'header' && uhsg_obar_is_valid_obar_route_and_domain()) {
     $config = \Drupal::config('uhsg_obar.settings');
     $variables['obar_base_url'] = $config->get('base_url');
     $variables['obar_app_name'] = $config->get('app_name');
@@ -39,7 +39,7 @@ function uhsg_obar_preprocess_region(&$variables) {
  */
 function uhsg_obar_theme_suggestions_region_alter(&$suggestions, $variables, $hook) {
   if ($variables['elements']['#region'] == 'header') {
-    if (\Drupal::service('uhsg_domain.domain')->isStudentDomain()) {
+    if (uhsg_obar_is_valid_obar_route_and_domain()) {
       array_push($suggestions, 'region__header__obar');
     }
   }
@@ -49,8 +49,19 @@ function uhsg_obar_theme_suggestions_region_alter(&$suggestions, $variables, $ho
  * Implements hook_page_attachments_alter().
  */
 function uhsg_obar_page_attachments_alter(&$page) {
-  if (!\Drupal::service('router.admin_context')->isAdminRoute() && \Drupal::service('uhsg_domain.domain')->isStudentDomain()) {
+  if (uhsg_obar_is_valid_obar_route_and_domain()) {
     $page['#attached']['drupalSettings']['uhsgObar']['obarBaseUrl'] = \Drupal::config('uhsg_obar.settings')->get('base_url');
     $page['#attached']['library'][] = 'uhsg_obar/uhsg_obar.obar';
   }
+}
+
+/**
+ * Returns TRUE when the current route is not admin route and the current
+ * domain is student domain. Otherwise returns FALSE.
+ *
+ * @return bool
+ */
+function uhsg_obar_is_valid_obar_route_and_domain() {
+  return !\Drupal::service('router.admin_context')->isAdminRoute()
+    && \Drupal::service('uhsg_domain.domain')->isStudentDomain();
 }


### PR DESCRIPTION
Do not attach Obar library on admin UI

Obar is not needed on the admin UI. This change adds a check for admin route so that the library is not attached unnecessarily.