### PR TITLE
Feature/hub 480 allow no content response in oprek service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: ??.??.????
 * Do not attach Obar library on admin UI (HUB-476)
 * Display user group on search filters and results (HUB-452)
 * Updated Drupal core (HUB-478)
+* Do not display error on empty study rights response (HUB-480)
 
 
 ## 1.36

--- a/modules/uhsg_oprek/src/Oprek/OprekService.php
+++ b/modules/uhsg_oprek/src/Oprek/OprekService.php
@@ -78,7 +78,7 @@ class OprekService implements OprekServiceInterface {
     $response = $this->client->get($this->config->get('base_url') . $uri, ['cert' => $this->config->get('cert_filepath'), 'ssl_key' => $this->config->get('cert_key_filepath')]);
     if ($response->getStatusCode() == 200) {
       $body = Json::decode($response->getBody()->getContents());
-      if ($this->getStatusFromBody($body) == 200) {
+      if (in_array($this->getStatusFromBody($body), [200, 204])) {
         return $this->getDataFromBody($body);
       }
       else {


### PR DESCRIPTION
# Allow 204 No Content response in OprekService

## Behavior before this change

Displayed an error message when the study rights API returned empty response (204 code in the response body and 200 as HTTP response). This is incorrect, because some users have a student number but no study rights (many of the teachers, for example). This response should be considered as normal, not as an exception.

## Behavior after this change

204 response body code does not throw an exception anymore and no error is displayed.
