### PR TITLE
HUB-481: Use variable domain URL scheme to support both http and https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release date: ??.??.????
 * Updated Drupal core (HUB-478)
 * Do not display error on empty study rights response (HUB-480)
 * Show body summary field on edit by default (HUB-475)
+* Domain (technical): Use variable domain URL scheme (HUB-481)
 
 
 ## 1.36

--- a/config/sync/domain.record.guide_student_helsinki_fi.yml
+++ b/config/sync/domain.record.guide_student_helsinki_fi.yml
@@ -6,6 +6,6 @@ id: guide_student_helsinki_fi
 domain_id: 4349307
 hostname: guide.student.helsinki.fi
 name: 'Instructions for students'
-scheme: https
+scheme: variable
 weight: 1
 is_default: true

--- a/config/sync/domain.record.guide_teacher_helsinki_fi.yml
+++ b/config/sync/domain.record.guide_teacher_helsinki_fi.yml
@@ -6,6 +6,6 @@ id: guide_teacher_helsinki_fi
 domain_id: 15834470
 hostname: teaching.helsinki.fi
 name: 'Instructions for teaching'
-scheme: https
+scheme: variable
 weight: 2
 is_default: false


### PR DESCRIPTION
Local environment only supports http protocol. Dev and prod support
https. Domain tries to redirect domain content to https also on
localhost, resulting in a failure. This configuration change uses
variable URL scheme that will work dynamically based on the incoming
web request, thus making the redirects work correctly in http and https
enabled environments.