### PR TITLE
Feature/hub 639 mobility services chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.39-dev
 Release date: ??.??.????
-* ..
+* Added giosg chat (HUB-639)
 
 
 ## 1.38

--- a/modules/uhsg_chat/config/schema/uhsg_chat.config.schema.yml
+++ b/modules/uhsg_chat/config/schema/uhsg_chat.config.schema.yml
@@ -2,7 +2,7 @@
 
 uhsg_chat.config:
   type: config_object
-  label: 'Chat configuration'
+  label: 'Smartupp chat configuration'
   mapping:
     display_chat_on_nodes:
       type: sequence

--- a/modules/uhsg_chat/config/schema/uhsg_chat.config.schema.yml
+++ b/modules/uhsg_chat/config/schema/uhsg_chat.config.schema.yml
@@ -2,7 +2,7 @@
 
 uhsg_chat.config:
   type: config_object
-  label: 'Smartupp chat configuration'
+  label: 'Smartsupp chat configuration'
   mapping:
     display_chat_on_nodes:
       type: sequence

--- a/modules/uhsg_chat/js/giosg_chat.js
+++ b/modules/uhsg_chat/js/giosg_chat.js
@@ -1,0 +1,9 @@
+// <!-- giosg tag -->
+(function(w, t, f) {
+ var s='script',o='_giosg',h='https://service.giosg.com',e,n;e=t.createElement(s);e.async=1;e.src=h+'/live/';
+ w[o]=w[o]||function()
+
+{(w[o]._e=w[o]._e||[]).push(arguments)}
+;w[o]._c=f;w[o]._h=h;n=t.getElementsByTagName(s)[0];n.parentNode.insertBefore(e,n);
+})(window,document,5261);
+//  <!-- giosg tag -->

--- a/modules/uhsg_chat/js/giosg_chat.js
+++ b/modules/uhsg_chat/js/giosg_chat.js
@@ -1,9 +1,4 @@
-// <!-- giosg tag -->
 (function(w, t, f) {
- var s='script',o='_giosg',h='https://service.giosg.com',e,n;e=t.createElement(s);e.async=1;e.src=h+'/live/';
- w[o]=w[o]||function()
-
-{(w[o]._e=w[o]._e||[]).push(arguments)}
-;w[o]._c=f;w[o]._h=h;n=t.getElementsByTagName(s)[0];n.parentNode.insertBefore(e,n);
+  var s='script',o='_giosg',h='https://service.giosg.com',e,n;e=t.createElement(s);e.async=1;e.src=h+'/live/';
+  w[o]=w[o]||function(){(w[o]._e=w[o]._e||[]).push(arguments)};w[o]._c=f;w[o]._h=h;n=t.getElementsByTagName(s)[0];n.parentNode.insertBefore(e,n);
 })(window,document,5261);
-//  <!-- giosg tag -->

--- a/modules/uhsg_chat/src/Form/ChatConfigForm.php
+++ b/modules/uhsg_chat/src/Form/ChatConfigForm.php
@@ -13,7 +13,7 @@ class ChatConfigForm extends ConfigFormBase {
     public function getFormId() {
       return 'uhsg_chat_config';
     }
-  
+
     /**
      * {@inheritdoc}
      */
@@ -26,10 +26,10 @@ class ChatConfigForm extends ConfigFormBase {
      */
     public function buildForm(array $form, FormStateInterface $form_state) {
       $chat_config = $this->config('uhsg_chat.config');
-  
+
       $form['uhsg_chat'] = [
         '#type' => 'details',
-        '#title' => t('Chat configuration'),
+        '#title' => t('Smartsupp chat configuration'),
         '#description' => t('Note: Node IDs are configured programmatically or using drush!'),
         '#open' => TRUE,
       ];
@@ -70,7 +70,7 @@ class ChatConfigForm extends ConfigFormBase {
         '#title' => t('Info description'),
         '#default_value' => $chat_config->get('infoDesc'),
       ];
-  
+
       return parent::buildForm($form, $form_state);
     }
 
@@ -87,7 +87,7 @@ class ChatConfigForm extends ConfigFormBase {
         ->set('infoTitle', $form_state->getValue('infoTitle'))
         ->set('infoDesc', $form_state->getValue('infoDesc'))
         ->save();
-  
+
       parent::submitForm($form, $form_state);
     }
 

--- a/modules/uhsg_chat/uhsg_chat.info.yml
+++ b/modules/uhsg_chat/uhsg_chat.info.yml
@@ -1,6 +1,6 @@
 name: Chat
 type: module
-description: Embed chat widget.
+description: Embed chat widgets Smartsupp and Giosg.
 core: 8.x
 version: VERSION
 package: Student Guide

--- a/modules/uhsg_chat/uhsg_chat.libraries.yml
+++ b/modules/uhsg_chat/uhsg_chat.libraries.yml
@@ -4,3 +4,8 @@ chat:
     js/chat.js: {}
   dependencies:
     - core/drupalSettings
+
+giosg_chat:
+  version: 1.x
+  js:
+    js/giosg_chat.js: {}

--- a/modules/uhsg_chat/uhsg_chat.module
+++ b/modules/uhsg_chat/uhsg_chat.module
@@ -26,10 +26,9 @@ function uhsg_chat_page_attachments(array &$attachments) {
       $attachments['#attached']['drupalSettings']['uhsg_chat']['infoDesc'] = $config->get('infoDesc');
       $attachments['#attached']['drupalSettings']['uhsg_chat']['currentLanguage'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
     }
+
+    // The Giosg chat script is added to every node page, but only activated in specific
+    // paths remotely in giosg console. Currently no settings defined in Drupal.
+    $attachments['#attached']['library'][] = 'uhsg_chat/giosg_chat';
   }
-
-  // The Giosg chat script is added to every page, but activated in specific
-  // paths remotely in giosg console. Currently no settings defined in Drupal.
-  $attachments['#attached']['library'][] = 'uhsg_chat/giosg_chat';
-
 }

--- a/modules/uhsg_chat/uhsg_chat.module
+++ b/modules/uhsg_chat/uhsg_chat.module
@@ -27,4 +27,9 @@ function uhsg_chat_page_attachments(array &$attachments) {
       $attachments['#attached']['drupalSettings']['uhsg_chat']['currentLanguage'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
     }
   }
+
+  // The Giosg chat script is added to every page, but activated in specific
+  // paths remotely in giosg console. Currently no settings defined in Drupal.
+  $attachments['#attached']['library'][] = 'uhsg_chat/giosg_chat';
+
 }


### PR DESCRIPTION
Added giosg.js which is currently loaded on _every_ page, including admin => EDIT: node pages only.

The path specific visibility should be controlled by a separate Giosg control panel which I dont have access to. Unfortunately it also seems that chat is domain specific and 
http://local.guide.student.helsinki.fi/admin is not whitelisted on the side of Giosg.

These domains should probably be whitelisted
local.guide.student.helsinki.fi
dev.guide.student.helsinki.fi
guide.student.helsinki.fi
(same for instruction-domains?)

Otherwise we get a 403 reply from Giosg:
https://service.giosg.com/api/v2/visitor/settings/5261/?url=http%3A%2F%2Flocal.guide.student.helsinki.fi%2Ffi

It complains:
{detail: "Domain not found!"}
detail: "Domain not found!"
