### PR TITLE
Feature/hub 644 disable caching for search view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: xx.xx.xxxx
 * Exclude old news from search results (HUB-642)
 * Add faculty support (HUB-370)
 * Add application-specific Obar footer (HUB-285)
+* Disable search caching to avoid incorrect results (HUB-644)
 
 
 ## 1.39

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -29,7 +29,7 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: search_api_tag
+        type: none
         options: {  }
       query:
         type: views_query


### PR DESCRIPTION
Remove search view caching to avoid incorrect (old, stale) results. Did not seem to have any huge performance implications. Since the search term is mandatory, hitting the exact same term is not too common. Overall the results processing (after Solr returns results) is pretty slow and could be improved. This change does not seem to affect the performance too much, so the bottlenecks are outside of caching.