### PR TITLE
HUB-646: Paragraph faculty selection

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.paragraph.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.paragraph.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.paragraph.field_paragraph_body
     - field.field.paragraph.paragraph.field_paragraph_degree_programme
+    - field.field.paragraph.paragraph.field_paragraph_faculty
     - field.field.paragraph.paragraph.field_paragraph_image
     - field.field.paragraph.paragraph.field_paragraph_links
     - field.field.paragraph.paragraph.field_paragraph_other_education
@@ -31,6 +32,15 @@ content:
     type: text_textarea
     region: content
   field_paragraph_degree_programme:
+    weight: 6
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_paragraph_faculty:
     weight: 5
     settings:
       match_operator: CONTAINS
@@ -56,7 +66,7 @@ content:
     type: link_default
     region: content
   field_paragraph_other_education:
-    weight: 6
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -73,7 +83,7 @@ content:
     type: string_textfield
     region: content
   field_paragraph_video:
-    weight: 7
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: video_embed_field_textfield

--- a/config/sync/core.entity_view_display.paragraph.paragraph.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.paragraph.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.paragraph.field_paragraph_body
     - field.field.paragraph.paragraph.field_paragraph_degree_programme
+    - field.field.paragraph.paragraph.field_paragraph_faculty
     - field.field.paragraph.paragraph.field_paragraph_image
     - field.field.paragraph.paragraph.field_paragraph_links
     - field.field.paragraph.paragraph.field_paragraph_other_education
@@ -36,6 +37,14 @@ content:
     settings:
       link: false
     third_party_settings: {  }
+    region: content
+  field_paragraph_faculty:
+    weight: 7
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_paragraph_image:
     weight: 5

--- a/config/sync/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -1,0 +1,29 @@
+uuid: b5a9c007-4ce5-4a83-a089-92dcf2efee29
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_faculty
+    - paragraphs.paragraphs_type.paragraph
+    - taxonomy.vocabulary.faculty
+id: paragraph.paragraph.field_paragraph_faculty
+field_name: field_paragraph_faculty
+entity_type: paragraph
+bundle: paragraph
+label: Faculty
+description: 'Assigning a faculty or multiple faculties will automatically assign the degree programmes on save.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      faculty: faculty
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/field.storage.paragraph.field_paragraph_faculty.yml
@@ -1,0 +1,20 @@
+uuid: ed7d4ad6-a030-4272-8b37-6f68beac463a
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_paragraph_faculty
+field_name: field_paragraph_faculty
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/fi/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/language/fi/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -1,0 +1,2 @@
+label: Tiedekunta
+description: 'Tiedekunnan tai tiedekuntien valitseminen asettaa koulutusohjelmat automaattisesti tallennuksen yhteydessä.'

--- a/config/sync/language/sv/field.field.node.article.field_article_faculty.yml
+++ b/config/sync/language/sv/field.field.node.article.field_article_faculty.yml
@@ -1,1 +1,2 @@
 label: Fakultet
+description: 'När du väljer fakultet väljer du samtidigt alla utbildningsprogram som är kopplade till fakulteten.'

--- a/config/sync/language/sv/field.field.node.news.field_news_faculty.yml
+++ b/config/sync/language/sv/field.field.node.news.field_news_faculty.yml
@@ -1,1 +1,2 @@
 label: Fakultet
+description: 'När du väljer fakultet väljer du samtidigt alla utbildningsprogram som är kopplade till fakulteten.'

--- a/config/sync/language/sv/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/language/sv/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -1,0 +1,1 @@
+label: Fakultet

--- a/config/sync/language/sv/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/language/sv/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -1,1 +1,2 @@
 label: Fakultet
+description: 'När du väljer fakultet väljer du samtidigt alla utbildningsprogram som är kopplade till fakulteten.'

--- a/modules/uhsg_article/uhsg_article.module
+++ b/modules/uhsg_article/uhsg_article.module
@@ -25,9 +25,16 @@ function uhsg_article_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_presave().
+ * Implements hook_ENTITY_TYPE_presave() for node.
  */
 function uhsg_article_node_presave(EntityInterface $entity) {
+  uhsg_article_assign_degree_programmes_by_faculties($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for paragraph.
+ */
+function uhsg_article_paragraph_presave(EntityInterface $entity) {
   uhsg_article_assign_degree_programmes_by_faculties($entity);
 }
 
@@ -35,15 +42,32 @@ function uhsg_article_node_presave(EntityInterface $entity) {
  * Assign degree programmes by faculties.
  */
 function uhsg_article_assign_degree_programmes_by_faculties(EntityInterface $entity) {
-  if (in_array($entity->bundle(), ['article'])) {
-    $faculty_terms = $entity->get('field_article_faculty')->referencedEntities();
+  $field_degree_programme = NULL;
+  $field_faculty = NULL;
+  $entity_type_bundle_key = $entity->getEntityTypeId() . '|' . $entity->bundle();
+
+  // Set field names depending on entity type + bundle combination.
+  switch ($entity_type_bundle_key) {
+    case 'node|article':
+      $field_degree_programme = 'field_article_degree_programme';
+      $field_faculty = 'field_article_faculty';
+      break;
+
+    case 'paragraph|paragraph':
+      $field_degree_programme = 'field_paragraph_degree_programme';
+      $field_faculty = 'field_paragraph_faculty';
+      break;
+  }
+
+  if ($field_degree_programme && $field_faculty) {
+    $faculty_terms = $entity->get($field_faculty)->referencedEntities();
     
     if (!empty($faculty_terms)) {
 
       // Existing article degree programme term IDs.
       $existing_article_degree_programme_term_ids = array_map(function ($reference) {
         return $reference['target_id'];
-      }, $entity->get('field_article_degree_programme')->getValue());
+      }, $entity->get($field_degree_programme)->getValue());
 
       // Faculty degree programme term IDs.
       $faculty_degree_programme_term_ids = [];
@@ -61,11 +85,11 @@ function uhsg_article_assign_degree_programmes_by_faculties(EntityInterface $ent
       ));
 
       // Reset article degree programme term IDs.
-      $entity->field_article_degree_programme = [];
+      $entity->{$field_degree_programme} = [];
 
       // Store merged degree programme term references.
       foreach ($merged_article_degree_programme_term_ids as $degree_programme_term_id) {
-        $entity->field_article_degree_programme[] = ['target_id' => $degree_programme_term_id];
+        $entity->{$field_degree_programme}[] = ['target_id' => $degree_programme_term_id];
       }
     }
   }

--- a/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
+++ b/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
@@ -41,6 +41,7 @@
     <div class="col-left">
       <h2 class="h3"> {{ content.field_paragraph_title }} </h2>
       {{ content.field_paragraph_degree_programme }}
+      {{ content.field_paragraph_faculty }}
       {{ content.field_paragraph_other_education }}
       {{ content.field_paragraph_image }}
       {{ content.field_paragraph_video }}

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -558,6 +558,7 @@ function uhsg_theme_theme_suggestions_field_alter(&$suggestions, $vars, $hook) {
     'field_news_degree_programme',
     'field_news_faculty',
     'field_paragraph_degree_programme',
+    'field_paragraph_faculty',
     'field_paragraph_other_education',
     'field_other_education_provider',
   ];


### PR DESCRIPTION
Extends the Faculty feature introduced in https://github.com/UH-StudentServices/student_guide/pull/317 / https://jira.it.helsinki.fi/browse/HUB-370 to Paragraph-type paragraphs:

- Adds a Faculty field to Paragraph-paragraph form and view displays
- Populates the Paragraph-paragraph Degree programmes field on a presave hook based on Faculty field content 