### PR TITLE
HUB-687: Faculty texts

### DIFF
--- a/config/sync/field.field.node.article.field_article_faculty.yml
+++ b/config/sync/field.field.node.article.field_article_faculty.yml
@@ -11,7 +11,7 @@ field_name: field_article_faculty
 entity_type: node
 bundle: article
 label: Faculty
-description: 'Assigning a faculty or multiple faculties will automatically assign the degree programmes on save.'
+description: 'When assigning a faculty or multiple faculties, the content will be automatically assigned to all degree programmes regarding the faculty/faculties in question.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.news.field_news_faculty.yml
+++ b/config/sync/field.field.node.news.field_news_faculty.yml
@@ -11,7 +11,7 @@ field_name: field_news_faculty
 entity_type: node
 bundle: news
 label: Faculty
-description: 'Assigning a faculty or multiple faculties will automatically assign the degree programmes on save.'
+description: 'When assigning a faculty or multiple faculties, the content will be automatically assigned to all degree programmes regarding the faculty/faculties in question.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -11,7 +11,7 @@ field_name: field_paragraph_faculty
 entity_type: paragraph
 bundle: paragraph
 label: Faculty
-description: 'Assigning a faculty or multiple faculties will automatically assign the degree programmes on save.'
+description: 'When assigning a faculty or multiple faculties, the content will be automatically assigned to all degree programmes regarding the faculty/faculties in question.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/language/fi/field.field.node.article.field_article_faculty.yml
+++ b/config/sync/language/fi/field.field.node.article.field_article_faculty.yml
@@ -1,2 +1,2 @@
 label: Tiedekunta
-description: 'Tiedekunnan tai tiedekuntien valitseminen asettaa koulutusohjelmat automaattisesti tallennuksen yhteydessä.'
+description: 'Valitessasi yhden tai useamman tiedekunnan, kiinnittyy sisältö automaattisesti kaikkiin ko. tiedekunnan/tiedekuntien koulutusohjelmiin.'

--- a/config/sync/language/fi/field.field.node.news.field_news_faculty.yml
+++ b/config/sync/language/fi/field.field.node.news.field_news_faculty.yml
@@ -1,2 +1,2 @@
 label: Tiedekunta
-description: 'Tiedekunnan tai tiedekuntien valitseminen asettaa koulutusohjelmat automaattisesti tallennuksen yhteydessä.'
+description: 'Valitessasi yhden tai useamman tiedekunnan, kiinnittyy sisältö automaattisesti kaikkiin ko. tiedekunnan/tiedekuntien koulutusohjelmiin.'

--- a/config/sync/language/fi/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/language/fi/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -1,2 +1,2 @@
 label: Tiedekunta
-description: 'Tiedekunnan tai tiedekuntien valitseminen asettaa koulutusohjelmat automaattisesti tallennuksen yhteydessä.'
+description: 'Valitessasi yhden tai useamman tiedekunnan, kiinnittyy sisältö automaattisesti kaikkiin ko. tiedekunnan/tiedekuntien koulutusohjelmiin.'

--- a/config/sync/language/sv/field.field.node.article.field_article_faculty.yml
+++ b/config/sync/language/sv/field.field.node.article.field_article_faculty.yml
@@ -1,2 +1,2 @@
 label: Fakultet
-description: 'När du väljer fakultet väljer du samtidigt alla utbildningsprogram som är kopplade till fakulteten.'
+description: 'När du väljer en eller flera fakulteter kopplas innehållet automatiskt till alla utbildningsprogram ifrågavarande fakulteten/fakulteterna.'

--- a/config/sync/language/sv/field.field.node.news.field_news_faculty.yml
+++ b/config/sync/language/sv/field.field.node.news.field_news_faculty.yml
@@ -1,2 +1,2 @@
 label: Fakultet
-description: 'När du väljer fakultet väljer du samtidigt alla utbildningsprogram som är kopplade till fakulteten.'
+description: 'När du väljer en eller flera fakulteter kopplas innehållet automatiskt till alla utbildningsprogram ifrågavarande fakulteten/fakulteterna.'

--- a/config/sync/language/sv/field.field.paragraph.paragraph.field_paragraph_faculty.yml
+++ b/config/sync/language/sv/field.field.paragraph.paragraph.field_paragraph_faculty.yml
@@ -1,2 +1,2 @@
 label: Fakultet
-description: 'När du väljer fakultet väljer du samtidigt alla utbildningsprogram som är kopplade till fakulteten.'
+description: 'När du väljer en eller flera fakulteter kopplas innehållet automatiskt till alla utbildningsprogram ifrågavarande fakulteten/fakulteterna.'

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -40,7 +40,7 @@ gulp.task('sass', (done) => {
 
 gulp.task('watch', gulp.series('sass', () => {
   process.chdir(paths.theme);
-  gulp.watch('sass/**/*.scss', ['sass']);
+  gulp.watch('sass/**/*.scss', gulp.series('sass'));
 }));
 
 gulp.task('bower', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,9 +127,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-jsx": {
       "version": "5.2.0",


### PR DESCRIPTION
Updating the Faculty field description text in all languages and for all use cases: Instructions and Bulletin content types and the Paragraph paragraph.

Also updating npm package `acorn` to resolve a dependabot PR. And fixing gulpfile to allow a proper `watch`-task run (caused by gulp version update from 3 to 4 a while back but was then left unnoticed).