### PR TITLE
HUB-714: Xml sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
-
+* HUB-714 - Adding an automatically generated sitemap.xml
 
 
 ## 1.44

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         "drupal/redirect": "^1.4",
         "drupal/externalauth": "1.1.0",
         "onelogin/php-saml": "v2.13.0",
-        "drupal/country_path": "^1.4"
+        "drupal/country_path": "^1.4",
+        "drupal/simple_sitemap": "^3.6"
     },
     "repositories": {
         "0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00b9515093ade8a3be801b9a361d0b33",
+    "content-hash": "239d30a1df1d5161b5e032a19e6b7197",
     "packages": [
         {
             "name": "UH-StudentServices/uh_courses_embed",
@@ -4407,6 +4407,60 @@
                 "source": "http://git.drupal.org/project/search_api_solr.git",
                 "issues": "https://www.drupal.org/project/issues/search_api_solr",
                 "irc": "irc://irc.freenode.org/drupal-search-api"
+            }
+        },
+        {
+            "name": "drupal/simple_sitemap",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_sitemap.git",
+                "reference": "8.x-3.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-8.x-3.6.zip",
+                "reference": "8.x-3.6",
+                "shasum": "37fc0ae98a4ccb23316cb089ae4839913e80cbf6"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "ext-xmlwriter": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.6",
+                    "datestamp": "1586469908",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Pawel Ginalski (gbyte.co)",
+                    "homepage": "https://www.drupal.org/u/gbyte.co",
+                    "email": "contact@gbyte.co",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Creates a standard conform hreflang XML sitemap of the site content and provides a framework for developing other sitemap types.",
+            "homepage": "https://drupal.org/project/simple_sitemap",
+            "support": {
+                "source": "https://cgit.drupalcode.org/simple_sitemap",
+                "issues": "https://drupal.org/project/issues/simple_sitemap",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {
@@ -11411,6 +11465,5 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -69,6 +69,7 @@ module:
   search_api_autocomplete: 0
   search_api_solr: 0
   serialization: 0
+  simple_sitemap: 0
   syslog: 0
   system: 0
   taxonomy: 0

--- a/config/sync/node.type.article.yml
+++ b/config/sync/node.type.article.yml
@@ -4,11 +4,24 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: Instructions
 type: article
 description: ''

--- a/config/sync/node.type.news.yml
+++ b/config/sync/node.type.news.yml
@@ -21,6 +21,7 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
+    publish_past_date_created: false
 name: Bulletin
 type: news
 description: ''

--- a/config/sync/node.type.theme.yml
+++ b/config/sync/node.type.theme.yml
@@ -4,11 +4,24 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: Theme
 type: theme
 description: ''

--- a/config/sync/simple_sitemap.bundle_settings.default.node.article.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.article.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.node.news.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.news.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.node.theme.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.theme.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.custom_links.default.yml
+++ b/config/sync/simple_sitemap.custom_links.default.yml
@@ -1,0 +1,7 @@
+links:
+  -
+    path: /
+    priority: '1.0'
+    changefreq: daily
+_core:
+  default_config_hash: 25hWeYa4sasuJtHqKKcEN_nYiuEC1lMPYHsn5dawJEw

--- a/config/sync/simple_sitemap.settings.yml
+++ b/config/sync/simple_sitemap.settings.yml
@@ -1,0 +1,15 @@
+max_links: 2000
+cron_generate: true
+cron_generate_interval: 0
+generate_duration: 10000
+remove_duplicates: true
+skip_untranslated: true
+xsl: true
+base_url: ''
+default_variant: default
+custom_links_include_images: false
+excluded_languages: {  }
+enabled_entity_types:
+  - node
+_core:
+  default_config_hash: LWI5gcV7qtIl5h1xg7AWMtepAzBAvTaw_TOmsQbw9Tk

--- a/config/sync/simple_sitemap.variants.default_hreflang.yml
+++ b/config/sync/simple_sitemap.variants.default_hreflang.yml
@@ -1,0 +1,6 @@
+variants:
+  default:
+    label: Default
+    weight: 0
+_core:
+  default_config_hash: nQAXscP-SDpsmqHlQ6u0iBvcuJPrAikb09c3cP2_n0k

--- a/config/sync/uhsg_role_auto_assign.settings.yml
+++ b/config/sync/uhsg_role_auto_assign.settings.yml
@@ -6,8 +6,8 @@ group_to_roles:
     group_name: hy-ypa-opa-kosu
     rid: content_editor
   -
-    group_name: grp-guide-editor
+    group_name: grp-guide-editor-dev
     rid: content_editor
   -
-    group_name: grp-guide-bulletin
+    group_name: grp-guide-bulletin-dev
     rid: bulletin_manager


### PR DESCRIPTION
This PR adds simple_sitemap-module to project and configures it to generate an xml sitemap with all News, Instructions and Theme content type nodes included.

### Testing

- Wait for Drupal cron to run or run it manually with `drush cron --uri=[site_url]` (--uri parameter is required for proper sitemap urls)
- Go to [site_url]/sitemap.xml