### PR TITLE
HUB-725 - Documented the new domains:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Instructions for students
 
-https://guide.student.helsinki.fi/
+https://guide.student.helsinki.fi/ (old)
+https://studies.helsinki.fi/ (new)
+
+Changes in may 2020
+There is a new domain set for student guide: studies-qa.it.helsinki.fi .
+Guide will be sharing the studies domain which also hosts multiple other services
+in the same root. Drupal is accessed via a proxy which reserves Drupal related
+language prefixed paths to student guide. Teaching instructions still remain
+in the old domain, which further complicates the setup.
+
+The new domains are:
+  - local.studies-qa.it.helsinki.fi
+  - dev.studies-qa.it.helsinki.fi
+  - studies.helsinki.fi
 
 # Instructions for teaching
 

--- a/config/sync/domain.record.guide_student_helsinki_fi.yml
+++ b/config/sync/domain.record.guide_student_helsinki_fi.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: guide_student_helsinki_fi
 domain_id: 4349307
-hostname: guide.student.helsinki.fi
+hostname: studies.helsinki.fi
 name: 'Instructions for students'
 scheme: variable
 weight: 1

--- a/config/sync/domain_alias.alias.guide_student_helsinki_fi_redirect.yml
+++ b/config/sync/domain_alias.alias.guide_student_helsinki_fi_redirect.yml
@@ -1,0 +1,9 @@
+uuid: d3641aab-8761-4a86-a669-15452730cc14
+langcode: fi
+status: true
+dependencies: {  }
+id: guide_student_helsinki_fi_redirect
+domain_id: guide_student_helsinki_fi
+pattern: guide.student.helsinki.fi
+redirect: 301
+environment: default

--- a/config/sync/domain_alias.alias.studies_helsinki_fi.yml
+++ b/config/sync/domain_alias.alias.studies_helsinki_fi.yml
@@ -1,9 +1,0 @@
-uuid: 166b34be-89ed-4877-aa18-b0183821c9be
-langcode: en
-status: true
-dependencies: {  }
-id: studies_helsinki_fi
-domain_id: guide_student_helsinki_fi
-pattern: studies.helsinki.fi
-redirect: 0
-environment: default

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -1,6 +1,6 @@
 uuid: 8054efdc-eb55-458c-ae62-16ab85de67a3
 name: 'Instructions for students'
-mail: no-reply@guide.student.helsinki.fi
+mail: no-reply@studies.helsinki.fi
 slogan: ''
 page:
   403: ''

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -15,7 +15,8 @@ const paths = {
   modules: `${rootDir}/modules`
 };
 
-const browserSyncProxyTarget = 'https://local.guide.student.helsinki.fi';
+// const browserSyncProxyTarget = 'https://local.guide.student.helsinki.fi';
+const browserSyncProxyTarget = 'https://local.studies-qa.it.helsinki.fi';
 
 const sass_config = {
   importer: globbing,

--- a/modules/uhsg_obar/src/Jwt.php
+++ b/modules/uhsg_obar/src/Jwt.php
@@ -158,9 +158,9 @@ class Jwt {
             'Bulletin archive'
           ],
           'url' => [
-            'https://guide.student.helsinki.fi/fi/news',
-            'https://guide.student.helsinki.fi/sv/news',
-            'https://guide.student.helsinki.fi/en/news'
+            'https://studies.helsinki.fi/ohjeet/news',
+            'https://studies.helsinki.fi/instruktioner/news',
+            'https://studies.helsinki.fi/instructions/news'
           ]
         ],
         'studentServices' => [
@@ -170,9 +170,9 @@ class Jwt {
             'Student Services'
           ],
           'url' => [
-            'https://guide.student.helsinki.fi/fi/artikkeli/opiskelijaneuvonta',
-            'https://guide.student.helsinki.fi/sv/artikel/studentservicen',
-            'https://guide.student.helsinki.fi/en/article/student-services'
+            'https://studies.helsinki.fi/ohjeet/artikkeli/opiskelijaneuvonta',
+            'https://studies.helsinki.fi/instruktioner/artikel/studentservicen',
+            'https://studies.helsinki.fi/instructions/article/student-services'
           ]
         ],
         'studentServicesAppointment' => [
@@ -194,9 +194,9 @@ class Jwt {
             'Career Services'
           ],
           'url' => [
-            'https://guide.student.helsinki.fi/fi/artikkeli/urapalvelujen-ohjaus-some-ja-yhteystiedot',
-            'https://guide.student.helsinki.fi/sv/artikel/karriarservicens-vagledning-evenemang-och-kontaktuppgifter',
-            'https://guide.student.helsinki.fi/en/article/career-servicesguidance-social-media-and-contact-details'
+            'https://studies.helsinki.fi/ohjeet/artikkeli/urapalvelujen-ohjaus-some-ja-yhteystiedot',
+            'https://studies.helsinki.fi/instruktioner/artikel/karriarservicens-vagledning-evenemang-och-kontaktuppgifter',
+            'https://studies.helsinki.fi/instructions/article/career-servicesguidance-social-media-and-contact-details'
           ]
         ],
         'exchangeServices' => [
@@ -206,9 +206,9 @@ class Jwt {
             'International Exchange Services'
           ],
           'url' => [
-            'https://guide.student.helsinki.fi/fi/artikkeli/ota-yhteytta-liikkuvuuspalveluihin',
-            'https://guide.student.helsinki.fi/sv/artikel/kontakta-mobilitetsservicen',
-            'https://guide.student.helsinki.fi/en/article/contact-international-exchange-services'
+            'https://studies.helsinki.fi/ohjeet/artikkeli/ota-yhteytta-liikkuvuuspalveluihin',
+            'https://studies.helsinki.fi/instruktioner/artikel/kontakta-mobilitetsservicen',
+            'https://studies.helsinki.fi/instructions/article/contact-international-exchange-services'
           ]
         ],
         'dataProtectionStatement' => [
@@ -218,9 +218,9 @@ class Jwt {
             'Data Protection Statement'
           ],
           'url' => [
-            'https://guide.student.helsinki.fi/fi/artikkeli/tietosuojailmoitus',
-            'https://guide.student.helsinki.fi/sv/artikel/dataskyddsmeddelande',
-            'https://guide.student.helsinki.fi/en/article/data-protection-statement'
+            'https://studies.helsinki.fi/ohjeet/artikkeli/tietosuojailmoitus',
+            'https://studies.helsinki.fi/instruktioner/artikel/dataskyddsmeddelande',
+            'https://studies.helsinki.fi/instructions/article/data-protection-statement'
           ]
         ]
       ]


### PR DESCRIPTION
https://guide.student.helsinki.fi/ (old)
https://studies.helsinki.fi/ (new)

Changes in may 2020
There is a new domain set for student guide: studies-qa.it.helsinki.fi .
Guide will be sharing the studies domain which also hosts multiple other services
in the same root. Drupal is accessed via a proxy which reserves Drupal related
language prefixed paths to student guide. Teaching instructions still remain
in the old domain, which further complicates the setup.

The new domains are:
  - local.studies-qa.it.helsinki.fi
  - dev.studies-qa.it.helsinki.fi
  - studies.helsinki.fi

NOTE: most of the changes are in the separate student_guide_infra repo.