### PR TITLE
HUB-710: Feedback email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-#Changelognn## 1.xx-devnRelease date: ??.??.????nn
+#Changelog
+
+## 1.xx-dev
+Release date: ??.??.????
+* HUB-710 - Updating feedback email
+
 
 ## 1.45
 Release date: 03.06.2020

--- a/config/sync/contact.form.feedback_form.yml
+++ b/config/sync/contact.form.feedback_form.yml
@@ -15,7 +15,7 @@ _core:
 id: feedback_form
 label: 'Feedback form'
 recipients:
-  - neu-tuki@helsinki.fi
+  - studies@helsinki.fi
 reply: ''
 weight: 0
 message: 'Thank you!'

--- a/config/sync/domain.config.guide_teacher_helsinki_fi.contact.form.feedback_form.yml
+++ b/config/sync/domain.config.guide_teacher_helsinki_fi.contact.form.feedback_form.yml
@@ -1,0 +1,2 @@
+recipients:
+  - guidance-coordination@helsinki.fi

--- a/modules/uhsg_feedback/uhsg_feedback.module
+++ b/modules/uhsg_feedback/uhsg_feedback.module
@@ -58,7 +58,7 @@ function uhsg_feedback_mail_alter(&$message) {
 
     // I would like to get a response to my feedback.
     if ($contact_message->get('field_feedback_respond')->value) {
-      $message['body'][] = t('I would like to get a response to my feedback: @replyTo', ['@replyto' => $replyTo]);
+      $message['body'][] = t('I would like to get a response to my feedback: @replyTo', ['@replyTo' => $replyTo]);
     }
 
     // Current page URL.


### PR DESCRIPTION
This PR updates global feedback email for the student guide and adds a domain config override to add a separate email for the teachers guide.

### Local testing (optional)

- Open both http://local.teaching.helsinki.fi/ohjeet and http://local.guide.student.helsinki.fi/ohjeet
- Send feedback from both sites
- Open mailhog: http://127.0.0.1:8025/ and check the recipient is correct for both emails:
  - Student guide: studies@helsinki.fi
  - Teachers guide: guidance-coordination@helsinki.fi