### PR TITLE
HUB-728: Remove cookie banner from Student guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-#Changelognn## 1.xx-devnRelease date: ??.??.????nn
+#Changelog
+
+## 1.xx-dev
+Release date: ??.??.????
+* HUB-728 - Removing cookie consent bar from Student guide
+
 
 ## 1.45
 Release date: 03.06.2020

--- a/modules/uhsg_cookie_consent/uhsg_cookie_consent.info.yml
+++ b/modules/uhsg_cookie_consent/uhsg_cookie_consent.info.yml
@@ -4,3 +4,5 @@ description: This module aims at making the website compliant with the new EU co
 core: 8.x
 version: VERSION
 package: Student Guide
+dependencies:
+  - uhsg_domain

--- a/modules/uhsg_cookie_consent/uhsg_cookie_consent.module
+++ b/modules/uhsg_cookie_consent/uhsg_cookie_consent.module
@@ -4,7 +4,12 @@
  * Implements hook_page_attachments().
  */
 function uhsg_cookie_consent_page_attachments(array &$page) {
-  if (\Drupal::currentUser()->isAnonymous()) {
+  // Show cookie consent bar only for anonymous users and on teaching
+  // instructions. Student guide will show a consent bar through obar. 
+  $is_anonymous = \Drupal::currentUser()->isAnonymous();
+  $is_teaching_domain = $is_anonymous && \Drupal::service('uhsg_domain.domain')->isTeachingDomain();
+
+  if ($is_anonymous && $is_teaching_domain) {
     $page['#attached']['library'][] = 'uhsg_cookie_consent/uhsg-cookie-consent';
     $page['#attached']['library'][] = 'uhsg_cookie_consent/cookieconsent2';
     $page['#attached']['drupalSettings']['uhsg_cookie_consent']['options'] = [


### PR DESCRIPTION
This PR limits the cookie consent banner to only appear on Teaching instructions domain as Student guide will start to show a cookie banner through obar.

### Testing

- Open both http://local.guide.student.helsinki.fi/instructions and http://local.teaching.helsinki.fi/ohjeet on an incognito browser
- You should only see one cookie banner in both, Student guide providing it through obar