### PR TITLE
Feature/hub 747 broken link prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* HUB-747 - Fix language prefix in some teaching -> guide links.
 
 
 ## 1.47

--- a/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
+++ b/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
@@ -60,7 +60,7 @@ class LinkToInstructionsForStudents extends BlockBase {
     }else{
       $language_prefix = $language;
     }
-    return $url . $language;
+    return $url . $language_prefix;
   }
 
   private function getLinkItemMarkup($uri, $label, $id) {

--- a/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
+++ b/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
@@ -52,13 +52,6 @@ class LinkToInstructionsForStudents extends BlockBase {
     $url = \Drupal::service('uhsg_domain.domain')->getStudentDomainUrl();
     $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
-    return $url . $language;
-  }
-
-  private function getUrl() {
-    $url = \Drupal::service('uhsg_domain.domain')->getStudentDomainUrl();
-    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-
     // Need to fetch correct language prefix, not just langcode,
     // although it by default matches the prefix. Moving to new studies domain
     // changes the requirements.

--- a/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
+++ b/modules/uhsg_domain/src/Plugin/Block/LinkToInstructionsForStudents.php
@@ -55,6 +55,21 @@ class LinkToInstructionsForStudents extends BlockBase {
     return $url . $language;
   }
 
+  private function getUrl() {
+    $url = \Drupal::service('uhsg_domain.domain')->getStudentDomainUrl();
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    // Need to fetch correct language prefix, not just langcode,
+    // although it by default matches the prefix. Moving to new studies domain
+    // changes the requirements.
+    if($prefixes = \Drupal::config('language.negotiation')->get('url.prefixes')) {
+      $language_prefix = $prefixes[$language];
+    }else{
+      $language_prefix = $language;
+    }
+    return $url . $language;
+  }
+
   private function getLinkItemMarkup($uri, $label, $id) {
     $url = Url::fromUri($uri, [
       'attributes' => [


### PR DESCRIPTION
Trivial change, need to use lang prefixes instead of lang code. This should fix teaching domain frontpage links to guide.