### PR TITLE
Feature/hub 750 disable login redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* HUB-750 - Login redirect based on OPINTONI_HAS_LOGGED_IN-cookie has been disabled.
 
 
 ## 1.47

--- a/modules/uhsg_redirect_to_login/src/StackMiddleware/RedirectToLogin.php
+++ b/modules/uhsg_redirect_to_login/src/StackMiddleware/RedirectToLogin.php
@@ -9,7 +9,16 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class RedirectToLogin implements HttpKernelInterface {
 
-  const COOKIE_NAME_LOGGED = 'OPINTONI_HAS_LOGGED_IN';
+  // https://jira.it.helsinki.fi/browse/HUB-750
+  // Redirect feature is a broken relic from the past, and after new studies
+  // proxy activation, it can cause redirect to wrong urls and confusion,
+  // especially if user has an old OO cookie. This SSO is causing more issues
+  // than it solves, and migh be totally refactored in near future.
+  // For now the redirect can be disabled, and that is easiest to do
+  // by renaming:
+  // OPINTONI_HAS_LOGGED_IN => OPINTONI_HAS_LOGGED_IN_DISABLED.
+  // Revert renaming if we have a sudden need to return it.
+  const COOKIE_NAME_LOGGED = 'OPINTONI_HAS_LOGGED_IN_DISABLED';
   const COOKIE_NAME_TRIGGERED = 'OPINTONI_HAS_LOGGED_IN_HAS_TRIGGERED';
 
   /**


### PR DESCRIPTION
Login redirect feature based on a shared cookie is a broken relic from the past, and after new studies
proxy activation, it can cause redirect to wrong urls and confusion,
especially if user has an old OO cookie. 

This SSO is causing more issues than it solves, and might be totally refactored in near future.
For now we just rename and in reality disable the cookie.
