### PR TITLE
Feature/hub 755 study rights fail

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4079,8 +4079,7 @@
             },
             "require": {
                 "drupal/core": "~8.0",
-                "drupal/externalauth": "*",
-                "onelogin/php-saml": "~2.5"
+                "drupal/externalauth": "*"
             },
             "type": "drupal-module",
             "extra": {
@@ -5277,6 +5276,184 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "laminas/laminas-diactoros",
+            "version": "1.8.7p2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-diactoros.git",
+                "reference": "6991c1af7c8d2c8efee81b22ba97024781824aaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/6991c1af7c8d2c8efee81b22ba97024781824aaa",
+                "reference": "6991c1af7c8d2c8efee81b22ba97024781824aaa",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "replace": {
+                "zendframework/zend-diactoros": "~1.8.7.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "laminas/laminas-coding-standard": "~1.0",
+                "php-http/psr7-integration-tests": "dev-master",
+                "phpunit/phpunit": "^5.7.16 || ^6.0.8 || ^7.2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-release-1.8": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/create_uploaded_file.php",
+                    "src/functions/marshal_headers_from_sapi.php",
+                    "src/functions/marshal_method_from_sapi.php",
+                    "src/functions/marshal_protocol_version_from_sapi.php",
+                    "src/functions/marshal_uri_from_sapi.php",
+                    "src/functions/normalize_server.php",
+                    "src/functions/normalize_uploaded_files.php",
+                    "src/functions/parse_cookie_header.php",
+                    "src/functions/create_uploaded_file.legacy.php",
+                    "src/functions/marshal_headers_from_sapi.legacy.php",
+                    "src/functions/marshal_method_from_sapi.legacy.php",
+                    "src/functions/marshal_protocol_version_from_sapi.legacy.php",
+                    "src/functions/marshal_uri_from_sapi.legacy.php",
+                    "src/functions/normalize_server.legacy.php",
+                    "src/functions/normalize_uploaded_files.legacy.php",
+                    "src/functions/parse_cookie_header.legacy.php"
+                ],
+                "psr-4": {
+                    "Laminas\\Diactoros\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "psr",
+                "psr-7"
+            ],
+            "time": "2020-03-23T15:28:28+00:00"
+        },
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-escaper": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:43:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-09-14T14:23:00+00:00"
         },
         {
             "name": "league/container",
@@ -8014,115 +8191,6 @@
             "time": "2019-10-02T17:01:11+00:00"
         },
         {
-            "name": "zendframework/zend-diactoros",
-            "version": "1.8.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "a85e67b86e9b8520d07e6415fcbcb8391b44a75b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/a85e67b86e9b8520d07e6415fcbcb8391b44a75b",
-                "reference": "a85e67b86e9b8520d07e6415fcbcb8391b44a75b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "php-http/psr7-integration-tests": "dev-master",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8 || ^7.2.7",
-                "zendframework/zend-coding-standard": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-release-1.8": "1.8.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions/create_uploaded_file.php",
-                    "src/functions/marshal_headers_from_sapi.php",
-                    "src/functions/marshal_method_from_sapi.php",
-                    "src/functions/marshal_protocol_version_from_sapi.php",
-                    "src/functions/marshal_uri_from_sapi.php",
-                    "src/functions/normalize_server.php",
-                    "src/functions/normalize_uploaded_files.php",
-                    "src/functions/parse_cookie_header.php"
-                ],
-                "psr-4": {
-                    "Zend\\Diactoros\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "PSR HTTP Message implementations",
-            "homepage": "https://github.com/zendframework/zend-diactoros",
-            "keywords": [
-                "http",
-                "psr",
-                "psr-7"
-            ],
-            "abandoned": "laminas/laminas-diactoros",
-            "time": "2019-08-06T17:53:53+00:00"
-        },
-        {
-            "name": "zendframework/zend-escaper",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-escaper.git",
-                "reference": "3801caa21b0ca6aca57fa1c42b08d35c395ebd5f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/3801caa21b0ca6aca57fa1c42b08d35c395ebd5f",
-                "reference": "3801caa21b0ca6aca57fa1c42b08d35c395ebd5f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Escaper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
-            "keywords": [
-                "ZendFramework",
-                "escaper",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-escaper",
-            "time": "2019-09-05T20:03:20+00:00"
-        },
-        {
             "name": "zendframework/zend-feed",
             "version": "2.12.0",
             "source": {
@@ -10160,6 +10228,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -11464,5 +11533,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/modules/uhsg_oprek/src/Oprek/OprekService.php
+++ b/modules/uhsg_oprek/src/Oprek/OprekService.php
@@ -6,6 +6,7 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\uhsg_oprek\Oprek\StudyRight\StudyRight;
 use GuzzleHttp\Client;
+use Drupal\Core\Site\Settings;
 
 /**
  * Service for interacting with backend integration service "Oprek".
@@ -21,6 +22,24 @@ class OprekService implements OprekServiceInterface {
    * @var \GuzzleHttp\Client
    */
   protected $client;
+
+  /**
+   * Use mock responses? This can be overridden in settings.local.php with:
+   *   $settings['uhsg_oprek_use_mock_response'] = TRUE;
+   *
+   * @var bool
+   */
+  const UHSG_OPREK_USE_MOCK_RESPONSE = FALSE;
+
+  /**
+   * Add debug logging?
+   * This can be overridden in settings.local.php with:
+   *   $settings['uhsg_oprek_add_debug_logging'] = TRUE;
+   *
+   * @var bool
+   */
+  const UHSG_OPREK_ADD_DEBUG_LOGGING = FALSE;
+
 
   /**
    * OprekService constructor.
@@ -75,20 +94,23 @@ class OprekService implements OprekServiceInterface {
       $uri = str_replace($key, $value, $uri);
     }
 
-    $response = $this->client->get($this->config->get('base_url') . $uri, ['cert' => $this->config->get('cert_filepath'), 'ssl_key' => $this->config->get('cert_key_filepath')]);
-    if ($response->getStatusCode() == 200) {
-      $body = Json::decode($response->getBody()->getContents());
-      if (in_array($this->getStatusFromBody($body), [200, 204])) {
-        return $this->getDataFromBody($body);
+    if (Settings::get('uhsg_oprek_use_mock_response', self::UHSG_OPREK_USE_MOCK_RESPONSE)) {
+      return $this->getDataFromMockResponse();
+    }else{
+      $response = $this->client->get($this->config->get('base_url') . $uri, ['cert' => $this->config->get('cert_filepath'), 'ssl_key' => $this->config->get('cert_key_filepath')]);
+      if ($response->getStatusCode() == 200) {
+        $body = Json::decode($response->getBody()->getContents());
+        if (in_array($this->getStatusFromBody($body), [200, 204])) {
+          return $this->getDataFromBody($body);
+        }
+        else {
+          throw new \Exception('Oprek service responded, but body status is not OK', ($response->getStatusCode() * 1000) + $this->getStatusFromBody($body));
+        }
       }
       else {
-        throw new \Exception('Oprek service responded, but body status is not OK', ($response->getStatusCode() * 1000) + $this->getStatusFromBody($body));
+        throw new \Exception('Oprek service did not responded OK', $response->getStatusCode() * 1000);
       }
     }
-    else {
-      throw new \Exception('Oprek service did not responded OK', $response->getStatusCode() * 1000);
-    }
-
   }
 
   /**
@@ -114,6 +136,778 @@ class OprekService implements OprekServiceInterface {
       return $body['data'];
     }
     return [];
+  }
+
+  /**
+   * Gets data payload from the body of a mock response.
+   * @return array
+   */
+  protected function getDataFromMockResponse() {
+    // This mock json is a real life example of a person (person_id anonymized)
+    // which earlier versions had trouble with. For example recognizing
+    // what is the primary study right/subject failed in rare cases.
+    $mock_json = '{
+          "md5": "686b62d963808b243679c7853e01fc3a",
+          "status": 200,
+          "elapsed": 0.025998623,
+          "data": [
+              {
+                  "degree_date": null,
+                  "duration_months": 83,
+                  "extent_code": 1,
+                  "person_id": 1500000,
+                  "study_start_date": "2019-07-31T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Ensisijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Primär studierätt"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Primary"
+                      }
+                  ],
+                  "faculty_code": "H20",
+                  "elements": [
+                      {
+                          "element_id": 10,
+                          "code": "00351",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2026-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Oikeusnotaarin tutkinto"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Rättsnotarie"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Bachelor of Laws"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 15,
+                          "code": "A2004",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2026-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Valtioneuvoston asetus (794/2004) yliopistojen tutkinnoista"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Statsrådets förordning (794/2004) om universitetsexamina"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Government Decree (794/2004) on University Degrees"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 20,
+                          "code": "KH20_001",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2026-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Oikeusnotaarin koulutusohjelma"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Utbildningsprogrammet för rättsnotarie"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Bachelor\'s Programme in Law"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 30,
+                          "code": "SH20_121",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2026-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Oikeustieteen koulutus, Helsinki"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Utbildning i juridik, Helsinfors"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Study programme in Law, Helsinki"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2019-06-30T21:00:00.000Z",
+                  "studyright_id": 131179515,
+                  "end_date": "2026-07-30T21:00:00.000Z",
+                  "duration_remaining_months": 70,
+                  "priority": 1,
+                  "start_date": "2019-07-31T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Alempi korkeakoulututkinto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Lägre högskoleexamen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Bachelor\'s Degree"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Oikeustieteellinen tiedekunta"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Juridiska fakulteten"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Faculty of Law"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "H20"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 83,
+                  "extent_code": 2,
+                  "person_id": 1505239,
+                  "study_start_date": null,
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Optio"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Option"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Option"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 10,
+                          "code": "YLTUTK",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2026-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Ylempi korkeakoulututkinto"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Högre högskoleexamen"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Second-cycle degree"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 15,
+                          "code": "A2004",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2026-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Valtioneuvoston asetus (794/2004) yliopistojen tutkinnoista"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Statsrådets förordning (794/2004) om universitetsexamina"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Government Decree (794/2004) on University Degrees"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2019-06-30T21:00:00.000Z",
+                  "studyright_id": 131179516,
+                  "end_date": "2026-07-30T21:00:00.000Z",
+                  "duration_remaining_months": 70,
+                  "priority": 6,
+                  "start_date": "2019-07-31T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Ylempi korkeakoulututkinto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Högre högskoleexamen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Master\'s Degree"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Oikeustieteellinen tiedekunta"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Juridiska fakulteten"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Faculty of Law"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "H20"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 9,
+                  "extent_code": 9,
+                  "person_id": 1505239,
+                  "study_start_date": "2020-03-19T22:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00997",
+                          "start_date": "2020-03-19T22:00:00.000Z",
+                          "end_date": "2020-12-28T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Muu koulutus, joka ei johda tutkintoon"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Andra fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Other Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 60,
+                          "code": "AY99319",
+                          "start_date": "2020-03-19T22:00:00.000Z",
+                          "end_date": "2020-12-28T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Avoin yo: Repetera svenska - Ruotsin perusrakenteiden ja sanaston kertausta (CEFR A2)"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Öppna uni: Förberedande kurs i svenska"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Open uni: Remedial Course in Swedish"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2020-03-19T22:00:00.000Z",
+                  "studyright_id": 135342004,
+                  "end_date": "2020-12-28T22:00:00.000Z",
+                  "duration_remaining_months": 3,
+                  "priority": 2,
+                  "start_date": "2020-03-19T22:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppet universitet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppna universitetet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "9301"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 8,
+                  "extent_code": 9,
+                  "person_id": 1505239,
+                  "study_start_date": "2020-03-19T22:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00997",
+                          "start_date": "2020-03-19T22:00:00.000Z",
+                          "end_date": "2020-12-03T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Muu koulutus, joka ei johda tutkintoon"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Andra fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Other Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 60,
+                          "code": "AYKK-RUOIK",
+                          "start_date": "2020-03-19T22:00:00.000Z",
+                          "end_date": "2020-12-03T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Avoin yo: Toisen kotimaisen kielen suullinen taito, ruotsi (CEFR B1)"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Öppna uni: Muntlig färdighet i andra inhemska språket, svensk (CEFR B1)"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Open uni: Oral Skills in the Second National Language, Swedish (CEFR B1)"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2020-03-19T22:00:00.000Z",
+                  "studyright_id": 135422037,
+                  "end_date": "2020-12-03T22:00:00.000Z",
+                  "duration_remaining_months": 2,
+                  "priority": 2,
+                  "start_date": "2020-03-19T22:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppet universitet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppna universitetet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "9301"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 10,
+                  "extent_code": 9,
+                  "person_id": 1505239,
+                  "study_start_date": "2020-03-21T22:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00997",
+                          "start_date": "2020-03-21T22:00:00.000Z",
+                          "end_date": "2021-02-20T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Muu koulutus, joka ei johda tutkintoon"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Andra fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Other Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 60,
+                          "code": "AYON-300",
+                          "start_date": "2020-03-21T22:00:00.000Z",
+                          "end_date": "2021-02-20T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Avoin yo: Tieteellisen kirjoittamisen perusteet"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Öppna uni: Grunderna i vetenskapligt skrivande"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Open uni: Basics in Scientific Writing"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2020-03-21T22:00:00.000Z",
+                  "studyright_id": 135772235,
+                  "end_date": "2021-02-20T22:00:00.000Z",
+                  "duration_remaining_months": 5,
+                  "priority": 2,
+                  "start_date": "2020-03-21T22:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppet universitet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppna universitetet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "9301"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 17,
+                  "extent_code": 9,
+                  "person_id": 1505239,
+                  "study_start_date": "2020-04-25T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00997",
+                          "start_date": "2020-04-25T21:00:00.000Z",
+                          "end_date": "2021-09-29T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Muu koulutus, joka ei johda tutkintoon"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Andra fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Other Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 60,
+                          "code": "AYON-P212",
+                          "start_date": "2020-04-25T21:00:00.000Z",
+                          "end_date": "2021-09-29T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Avoin yo: Immateriaalioikeus ja kuluttajaoikeus"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Öppna uni: Immaterialrätt och konsumenträtt"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Open uni: Intellectual Property Law and Consumer Law"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2020-04-25T21:00:00.000Z",
+                  "studyright_id": 136047260,
+                  "end_date": "2021-09-29T21:00:00.000Z",
+                  "duration_remaining_months": 12,
+                  "priority": 2,
+                  "start_date": "2020-04-25T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppet universitet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppna universitetet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "9301"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 5,
+                  "extent_code": 9,
+                  "person_id": 1505239,
+                  "study_start_date": "2020-05-29T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00997",
+                          "start_date": "2020-05-29T21:00:00.000Z",
+                          "end_date": "2020-10-30T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Muu koulutus, joka ei johda tutkintoon"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Andra fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Other Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 60,
+                          "code": "AYOIK-J492",
+                          "start_date": "2020-05-29T21:00:00.000Z",
+                          "end_date": "2020-10-30T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Avoin yo: Lääkintä- ja bio-oikeus"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Öppna uni: Medicinering- och biorätt"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Open uni: Health and Biomedical Law"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2020-05-29T21:00:00.000Z",
+                  "studyright_id": 136481975,
+                  "end_date": "2020-10-30T22:00:00.000Z",
+                  "duration_remaining_months": 1,
+                  "priority": 2,
+                  "start_date": "2020-05-29T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppet universitet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppna universitetet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "9301"
+              }
+          ]
+      }';
+
+    // Ensure arrays everywhere.
+    $mock_json = (array) json_decode($mock_json);
+    $mock_json['data'] = (array) $mock_json['data'];
+    foreach($mock_json['data'] as $key => $value){
+      $mock_json['data'][$key] = (array) $value;
+    }
+
+    if (Settings::get('uhsg_oprek_add_debug_logging', self::UHSG_OPREK_ADD_DEBUG_LOGGING)) {
+      \Drupal::logger('uhsg_oprek')->info('GetStudyRights was executed with mock response: <pre> @mock </pre>', [
+        '@mock' => print_r($mock_json['data'], TRUE),
+      ]);
+    }
+
+    return $mock_json['data'];
   }
 
 }

--- a/modules/uhsg_oprek/src/Oprek/OprekService.php
+++ b/modules/uhsg_oprek/src/Oprek/OprekService.php
@@ -32,6 +32,14 @@ class OprekService implements OprekServiceInterface {
   const UHSG_OPREK_USE_MOCK_RESPONSE = FALSE;
 
   /**
+   * Use complex mock responses if any? This can be overridden in settings.local.php with:
+   *   $settings['uhsg_oprek_use_mock_response_complex'] = FALSE;
+   *
+   * @var bool
+   */
+  const UHSG_OPREK_USE_MOCK_RESPONSE_COMPLEX = TRUE;
+
+  /**
    * Add debug logging?
    * This can be overridden in settings.local.php with:
    *   $settings['uhsg_oprek_add_debug_logging'] = TRUE;
@@ -39,7 +47,6 @@ class OprekService implements OprekServiceInterface {
    * @var bool
    */
   const UHSG_OPREK_ADD_DEBUG_LOGGING = FALSE;
-
 
   /**
    * OprekService constructor.
@@ -138,15 +145,28 @@ class OprekService implements OprekServiceInterface {
     return [];
   }
 
+
   /**
    * Gets data payload from the body of a mock response.
    * @return array
    */
   protected function getDataFromMockResponse() {
-    // This mock json is a real life example of a person (person_id anonymized)
-    // which earlier versions had trouble with. For example recognizing
-    // what is the primary study right/subject failed in rare cases.
-    $mock_json = '{
+    // Choose from simple or complex mock json. Both are
+    // real life examples but with person_id anonymized.
+    // In earlier versions recognizing the primary study right/subject
+    // of the complex response failed in some cases.
+    return $this->chooseMockResponse(Settings::get('uhsg_oprek_use_mock_response_complex', self::UHSG_OPREK_USE_MOCK_RESPONSE_COMPLEX));
+  }
+
+    /**
+     * Choose a mock response from a simple or more complex option.
+     * Both are real world cases with only person ID anymized.
+     * @param $complex - if TRUE, using complex response.
+     * @return array
+     */
+    protected function chooseMockResponse(bool $complex = TRUE) {
+      if($complex){
+        $mock_json = '{
           "md5": "686b62d963808b243679c7853e01fc3a",
           "status": 200,
           "elapsed": 0.025998623,
@@ -893,9 +913,818 @@ class OprekService implements OprekServiceInterface {
               }
           ]
       }';
+    }else{
+      $mock_json = '{
+          "md5": "1bfd0b8aaf367c20f36cc8040d546ed8",
+          "status": 200,
+          "elapsed": 0.027522776,
+          "data": [
+              {
+                  "degree_date": "2017-01-15T22:00:00.000Z",
+                  "duration_months": 53,
+                  "extent_code": 1,
+                  "person_id": 90000000,
+                  "study_start_date": "2012-07-31T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Suorittanut tutkinnon"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Avlagt examen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Graduated"
+                      }
+                  ],
+                  "faculty_code": "H10",
+                  "elements": [
+                      {
+                          "element_id": 10,
+                          "code": "00849",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2017-01-15T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Teologian kandidaatti"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Teologie kandidat"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Bachelor of Theology"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 15,
+                          "code": "A2004",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2017-01-15T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Valtioneuvoston asetus (794/2004) yliopistojen tutkinnoista"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Statsrådets förordning (794/2004) om universitetsexamina"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Government Decree (794/2004) on University Degrees"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 20,
+                          "code": "120009",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2013-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kirkkojen ja yhteiskunnan teologisiin tehtäviin valmistava koulutusohjelma"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Utbildningsprogrammet för kyrkliga och samhälleliga teologiska uppgifter"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Degree Programme in Theological Functions in Churches and Society"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 20,
+                          "code": "120013",
+                          "start_date": "2013-07-31T21:00:00.000Z",
+                          "end_date": "2017-01-15T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Koulun uskonnonopettajan tehtäviin valmistava koulutusohjelma"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Utbildningsprogrammet för skolornas religionslärare"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Degree Programme in Religion Teacher Education"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 30,
+                          "code": "130016",
+                          "start_date": "2013-07-31T21:00:00.000Z",
+                          "end_date": "2017-01-15T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kahden opetettavan aineen (Uskonto ja psykologia) linja"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Linje för lärare i två undervisningsämnen (Religion och psykologi)"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Teacher Education, Two School-Subjects Line (Religion and Psychology)"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 40,
+                          "code": "03101",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2017-01-15T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kirkkohistoria"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Kyrkohistoria"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Church History"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2012-07-16T21:00:00.000Z",
+                  "studyright_id": 90648547,
+                  "end_date": "2017-01-15T22:00:00.000Z",
+                  "duration_remaining_months": -45,
+                  "priority": 30,
+                  "start_date": "2012-07-31T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Alempi korkeakoulututkinto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Lägre högskoleexamen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Bachelor\'s Degree"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Teologinen tiedekunta"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Teologiska fakulteten"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Faculty of Theology"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "H10"
+              },
+              {
+                  "degree_date": "2019-02-24T22:00:00.000Z",
+                  "duration_months": 78,
+                  "extent_code": 2,
+                  "person_id": 90648546,
+                  "study_start_date": "2017-01-16T22:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Suorittanut tutkinnon"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Avlagt examen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Graduated"
+                      }
+                  ],
+                  "faculty_code": "H10",
+                  "elements": [
+                      {
+                          "element_id": 10,
+                          "code": "00331",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Teologian maisteri"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Teologie magister"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Master of Theology"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 15,
+                          "code": "A2004",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Valtioneuvoston asetus (794/2004) yliopistojen tutkinnoista"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Statsrådets förordning (794/2004) om universitetsexamina"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Government Decree (794/2004) on University Degrees"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 20,
+                          "code": "120009",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2013-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kirkkojen ja yhteiskunnan teologisiin tehtäviin valmistava koulutusohjelma"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Utbildningsprogrammet för kyrkliga och samhälleliga teologiska uppgifter"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Degree Programme in Theological Functions in Churches and Society"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 20,
+                          "code": "120013",
+                          "start_date": "2013-07-31T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Koulun uskonnonopettajan tehtäviin valmistava koulutusohjelma"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Utbildningsprogrammet för skolornas religionslärare"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Degree Programme in Religion Teacher Education"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 30,
+                          "code": "130016",
+                          "start_date": "2013-07-31T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kahden opetettavan aineen (Uskonto ja psykologia) linja"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Linje för lärare i två undervisningsämnen (Religion och psykologi)"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Teacher Education, Two School-Subjects Line (Religion and Psychology)"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 40,
+                          "code": "03110",
+                          "start_date": "2012-07-31T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Yleinen kirkkohistoria"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Allmän kyrkohistoria"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "General Church History"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2012-07-16T21:00:00.000Z",
+                  "studyright_id": 90648588,
+                  "end_date": "2019-02-24T22:00:00.000Z",
+                  "duration_remaining_months": -19,
+                  "priority": 30,
+                  "start_date": "2012-07-31T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Ylempi korkeakoulututkinto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Högre högskoleexamen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Master\'s Degree"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Kirkkohistoria (Church history)"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Institutionen för kyrkohistoria"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Department of Church History"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "H1002"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 71,
+                  "extent_code": 99,
+                  "person_id": 90648546,
+                  "study_start_date": "2013-07-31T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 50,
+                          "code": "477500",
+                          "start_date": "2013-07-31T21:00:00.000Z",
+                          "end_date": "2019-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "PSY100 Psykologian perusopinnot"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "PSY100 Grundstudier i psykologi"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "PSY100 Basic Studies in Psychology"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 50,
+                          "code": "477401",
+                          "start_date": "2013-07-31T21:00:00.000Z",
+                          "end_date": "2019-07-30T21:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "PSY200B Psykologian aineopinnot sivuaineopiskelijoille"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "PSY200B Psykologi, ämnesstudier (biämne)"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "PSY200B Psychology, Intermediate Studies (Minor Subject)"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2013-06-10T21:00:00.000Z",
+                  "studyright_id": 96490415,
+                  "end_date": "2019-07-30T21:00:00.000Z",
+                  "duration_remaining_months": -14,
+                  "priority": 2,
+                  "start_date": "2013-07-31T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Muut erilliset opinnot"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Andra fristående studier"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Other Non-Degree Studies"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Psykologia"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Psykologi"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Psychology"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "6302"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 56,
+                  "extent_code": 10,
+                  "person_id": 90648546,
+                  "study_start_date": "2014-05-26T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": "H40",
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00901",
+                          "start_date": "2014-05-26T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Erilliset opinnot, arvosanat yms."
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 40,
+                          "code": "03402",
+                          "start_date": "2014-05-26T21:00:00.000Z",
+                          "end_date": "2019-02-24T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Englantilainen filologia"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Engelsk filologi"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "English Philology"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2014-05-26T21:00:00.000Z",
+                  "studyright_id": 102286834,
+                  "end_date": "2019-02-24T22:00:00.000Z",
+                  "duration_remaining_months": -19,
+                  "priority": 2,
+                  "start_date": "2014-05-26T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Valinnaiset / Sivuaine"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Valfria / Biämne"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary Subject"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Englantilainen filologia"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Engelsk filologi"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "English Philology"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "4032"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 52,
+                  "extent_code": 2,
+                  "person_id": 90648546,
+                  "study_start_date": "2019-07-31T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Ensisijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Primär studierätt"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Primary"
+                      }
+                  ],
+                  "faculty_code": "H60",
+                  "elements": [
+                      {
+                          "element_id": 10,
+                          "code": "00337",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2023-12-30T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kasvatustieteen maisteri"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Pedagogie magister"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Master of Arts (Education)"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 15,
+                          "code": "A2004",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2023-12-30T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Valtioneuvoston asetus (794/2004) yliopistojen tutkinnoista"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Statsrådets förordning (794/2004) om universitetsexamina"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Government Decree (794/2004) on University Degrees"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 20,
+                          "code": "MH60_001",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2023-12-30T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Kasvatustieteiden maisteriohjelma"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Magisterprogrammet i pedagogik"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Master´s Programme in Education"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 30,
+                          "code": "SH60_042",
+                          "start_date": "2019-07-31T21:00:00.000Z",
+                          "end_date": "2023-12-30T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Yleinen ja aikuiskasvatustiede"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Allmän- och vuxenpedagogik"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "General and Adult Education"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2019-06-30T21:00:00.000Z",
+                  "studyright_id": 130726863,
+                  "end_date": "2023-12-30T22:00:00.000Z",
+                  "duration_remaining_months": 39,
+                  "priority": 1,
+                  "start_date": "2019-07-31T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Ylempi korkeakoulututkinto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Högre högskoleexamen"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Master\'s Degree"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Kasvatustieteellinen tiedekunta"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Pedagogiska fakulteten"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Faculty of Educational Sciences"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "H60"
+              },
+              {
+                  "degree_date": null,
+                  "duration_months": 9,
+                  "extent_code": 9,
+                  "person_id": 90648546,
+                  "study_start_date": "2020-05-10T21:00:00.000Z",
+                  "state": [
+                      {
+                          "langcode": "fi",
+                          "text": "Toissijainen"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Sekundär"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Secondary"
+                      }
+                  ],
+                  "faculty_code": null,
+                  "elements": [
+                      {
+                          "element_id": 0,
+                          "code": "00997",
+                          "start_date": "2020-05-10T21:00:00.000Z",
+                          "end_date": "2021-02-23T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Muu koulutus, joka ei johda tutkintoon"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Andra fristående studier"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Other Non-Degree Studies"
+                              }
+                          ]
+                      },
+                      {
+                          "element_id": 60,
+                          "code": "AYEDUK304",
+                          "start_date": "2020-05-10T21:00:00.000Z",
+                          "end_date": "2021-02-23T22:00:00.000Z",
+                          "name": [
+                              {
+                                  "langcode": "fi",
+                                  "text": "Avoin yo: Oppiminen ja asiantuntijuus työssä, organisaatiossa ja verkostoissa"
+                              },
+                              {
+                                  "langcode": "sv",
+                                  "text": "Öppna uni: Lärande och expertis i arbetslivet, organisationer och nätverk"
+                              },
+                              {
+                                  "langcode": "en",
+                                  "text": "Open uni: Learning and expertise in the working life, organisations and networks"
+                              }
+                          ]
+                      }
+                  ],
+                  "admission_date": "2020-05-10T21:00:00.000Z",
+                  "studyright_id": 136361664,
+                  "end_date": "2021-02-23T22:00:00.000Z",
+                  "duration_remaining_months": 5,
+                  "priority": 2,
+                  "start_date": "2020-05-10T21:00:00.000Z",
+                  "extent": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppet universitet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "organisation_name": [
+                      {
+                          "langcode": "fi",
+                          "text": "Avoin yliopisto"
+                      },
+                      {
+                          "langcode": "sv",
+                          "text": "Öppna universitetet"
+                      },
+                      {
+                          "langcode": "en",
+                          "text": "Open University"
+                      }
+                  ],
+                  "cancel_date": null,
+                  "organisation_code": "9301"
+              }
+          ]
+      }';
+    }
 
-    // Ensure arrays everywhere.
-    $mock_json = (array) json_decode($mock_json);
+    // Enforce arrays everywhere.
+    $mock_json = (array) json_decode($mock_json, TRUE);
     $mock_json['data'] = (array) $mock_json['data'];
     foreach($mock_json['data'] as $key => $value){
       $mock_json['data'][$key] = (array) $value;

--- a/modules/uhsg_oprek/src/Oprek/OprekService.php
+++ b/modules/uhsg_oprek/src/Oprek/OprekService.php
@@ -165,7 +165,9 @@ class OprekService implements OprekServiceInterface {
      * @return array
      */
     protected function chooseMockResponse(bool $complex = TRUE) {
+      $complexity = 'simple';
       if($complex){
+        $complexity = 'complex';
         $mock_json = '{
           "md5": "686b62d963808b243679c7853e01fc3a",
           "status": 200,
@@ -1731,8 +1733,8 @@ class OprekService implements OprekServiceInterface {
     }
 
     if (Settings::get('uhsg_oprek_add_debug_logging', self::UHSG_OPREK_ADD_DEBUG_LOGGING)) {
-      \Drupal::logger('uhsg_oprek')->info('GetStudyRights was executed with mock response: <pre> @mock </pre>', [
-        '@mock' => print_r($mock_json['data'], TRUE),
+      \Drupal::logger('uhsg_oprek')->info('GetStudyRights was executed with mock response of type <i>@complexity </i>.', [
+        '@complexity' => $complexity,
       ]);
     }
 

--- a/modules/uhsg_oprek/src/Oprek/StudyRight/StudyRight.php
+++ b/modules/uhsg_oprek/src/Oprek/StudyRight/StudyRight.php
@@ -96,6 +96,7 @@ class StudyRight implements StudyRightInterface {
        * @endcode
        */
       foreach ($this->properties['state'] as $state) {
+        $state = (array) $state;
         if (!empty($this->knownStates[$state['text']])) {
           return $this->knownStates[$state['text']];
         }
@@ -111,6 +112,7 @@ class StudyRight implements StudyRightInterface {
     $return = [];
     if (!empty($this->properties['elements']) && is_array($this->properties['elements'])) {
       foreach ($this->properties['elements'] as $element_raw) {
+        $element_raw = (array) $element_raw;
         $element = new Element($element_raw);
         $element->setDate($this->date);
         if ($element->isActive()) {

--- a/modules/uhsg_oprek/src/Oprek/StudyRight/StudyRight.php
+++ b/modules/uhsg_oprek/src/Oprek/StudyRight/StudyRight.php
@@ -189,6 +189,17 @@ class StudyRight implements StudyRightInterface {
 
     // Finally merge both assembled into one array of targeted codes
     $this->targetedCodes = array_merge($this->targetedCodesSingles, $this->targetedCodesConcatonated);
+
+    // Log the codes to make corner case debugging simpler.
+    $targetedCodes = array(
+      'targetedCodes' => (array) $this->targetedCodes,
+      'targetedCodesSingles' => (array) $this->targetedCodesSingles,
+      'targetedCodesConcatonated' => (array) $this->targetedCodesConcatonated,
+    );
+    \Drupal::logger('uhsg_oprek')->info('StudyRights/TargetedCodes were parsed for uid %uid as : <pre>@targeted_codes</pre>', [
+      '%uid' => \Drupal::currentUser()->id(),
+      '@targeted_codes' => print_r($targetedCodes, TRUE),
+    ]);
   }
 
 }

--- a/modules/uhsg_oprek/src/Oprek/StudyRight/StudyRight.php
+++ b/modules/uhsg_oprek/src/Oprek/StudyRight/StudyRight.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\uhsg_oprek\Oprek\StudyRight;
 
+use Drupal\Core\Site\Settings;
+
 /**
  * Represents StudyRight object.
  */
@@ -13,6 +15,15 @@ class StudyRight implements StudyRightInterface {
    * @var array
    */
   protected $properties;
+
+  /**
+   * Add debug logging?
+   * This can be overridden in settings.local.php with:
+   *   $settings['uhsg_oprek_add_debug_logging'] = TRUE;
+   *
+   * @var bool
+   */
+  const UHSG_OPREK_ADD_DEBUG_LOGGING = FALSE;
 
   /**
    * Contains a list of known states and their identifier strings that we look
@@ -127,7 +138,7 @@ class StudyRight implements StudyRightInterface {
    * {@inheritdoc}
    */
   public function getTargetedCodes() {
-    if (is_null($this->targetedCodes)) {
+    if (empty($this->targetedCodes)) {
       $this->targetedCodes = [];
       $this->assembleSingularTargetedCodes();
       $this->assembleConcatenatedTargetedCodes();
@@ -193,15 +204,17 @@ class StudyRight implements StudyRightInterface {
     $this->targetedCodes = array_merge($this->targetedCodesSingles, $this->targetedCodesConcatonated);
 
     // Log the codes to make corner case debugging simpler.
-    $targetedCodes = array(
-      'targetedCodes' => (array) $this->targetedCodes,
-      'targetedCodesSingles' => (array) $this->targetedCodesSingles,
-      'targetedCodesConcatonated' => (array) $this->targetedCodesConcatonated,
-    );
-    \Drupal::logger('uhsg_oprek')->info('StudyRights/TargetedCodes were parsed for uid %uid as : <pre>@targeted_codes</pre>', [
-      '%uid' => \Drupal::currentUser()->id(),
-      '@targeted_codes' => print_r($targetedCodes, TRUE),
-    ]);
+    if (!empty($this->targetedCodes) && Settings::get('uhsg_oprek_add_debug_logging', self::UHSG_OPREK_ADD_DEBUG_LOGGING)) {
+      $targetedCodes = array(
+        'targetedCodes' => (array) $this->targetedCodes,
+        'targetedCodesSingles' => (array) $this->targetedCodesSingles,
+        'targetedCodesConcatonated' => (array) $this->targetedCodesConcatonated,
+      );
+      \Drupal::logger('uhsg_oprek')->info('StudyRights/TargetedCodes were parsed for uid %uid as : <pre>@targeted_codes</pre>', [
+        '%uid' => \Drupal::currentUser()->id(),
+        '@targeted_codes' => print_r($targetedCodes, TRUE),
+      ]);
+    }
   }
 
 }

--- a/modules/uhsg_user_sync/src/SamlAuth/UserSyncSubscriber.php
+++ b/modules/uhsg_user_sync/src/SamlAuth/UserSyncSubscriber.php
@@ -16,6 +16,7 @@ use Drupal\uhsg_samlauth\AttributeParser;
 use Drupal\uhsg_samlauth\AttributeParserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Site\Settings;
 
 /**
  * Synchronise relevant user attributes given by SAML authentication during SAML
@@ -54,6 +55,15 @@ class UserSyncSubscriber implements EventSubscriberInterface {
    * @var \Drupal\Core\Messenger\MessengerInterface
    */
   protected $messenger;
+
+  /**
+   * Add debug logging?
+   * This can be overridden in settings.local.php with:
+   *   $settings['uhsg_oprek_add_debug_logging'] = TRUE;
+   *
+   * @var bool
+   */
+  const UHSG_OPREK_ADD_DEBUG_LOGGING = FALSE;
 
   public function __construct(ConfigFactoryInterface $configFactory, OprekServiceInterface $oprekService, FlagServiceInterface $flagService, EntityTypeManagerInterface $entityTypeManager, LoggerChannel $logger, MessengerInterface $messenger) {
     $this->config = $configFactory->get('uhsg_user_sync.settings');
@@ -311,8 +321,23 @@ class UserSyncSubscriber implements EventSubscriberInterface {
       $primary_field_name = $this->config->get('primary_field_name');
 
       foreach ($study_rights as $study_right) {
+        if (Settings::get('uhsg_oprek_add_debug_logging', self::UHSG_OPREK_ADD_DEBUG_LOGGING)) {
+          // Debug (a lot of) study right data. Enable only temporarily.
+          $known_degree_programmes_array = (array) $known_degree_programmes;
+          $targeted_codes_array = (array) $study_right->getTargetedCodes();
+          $known_degree_programme_keys = array_keys($known_degree_programmes_array);
+          \Drupal::logger('uhsg_oprek')->info('setTechnicalDegreeProgrammes(),
+            targeted codes are: <pre>@targeted_codes</pre> and
+            degree_programmes: <pre>@degree_programmes</pre>', [
+            '@targeted_codes' => print_r($targeted_codes_array, TRUE),
+            '@degree_programmes' => print_r($known_degree_programme_keys, TRUE),
+          ]);
+        }
+
         foreach ($study_right->getTargetedCodes() as $targeted_code) {
           if (isset($known_degree_programmes[$targeted_code->getCode()])) {
+
+
 
             // Flag the degree programme
             $flag = $this->flagService->getFlagById('my_degree_programmes');


### PR DESCRIPTION
Added mock responses, which have 2 choices, simple and complex. There are real world but anonymized use cases and the complex one includes the exact bug we trying to fix here.

Its clear that the bug is not about finding the study right and degree programme, as those are actually set correctly for the person affected. What is not set correctly is the "is_primary" field in the personal flagging of the degree programme.

"Ensisijainen" / "Optio" are read correctly but it appears in some cases the primary flag may be overridden or merged mistakenly in getTargetedCodes().

Debugging and verifying this locally can be done with "doo_12" for example (I used a db copy from dev). Logging in via samlauth and getting oprek handled works locally after changes in settings.local.php:

```
/*
* Use mock responses for oprek/DOO-OODI query fetching study rights?
* This only makes sense if debugging/developing locally.
*/
$settings['uhsg_oprek_use_mock_response'] = TRUE;
$settings['uhsg_oprek_add_debug_logging'] = TRUE;
```

The complex mock is supposed to add "Oikeusnotaarin koulutusohjelma" flagging to the user - and it does. But it does not yet set the flagging is_primary field to true, which is the definitive problem here. 

The end result is visible at the front page, "Valitse koulutusohjelma" -> "Koulutusohjelmani" -> "Oikeusnotaarin koulutusohjelma" at http://local.studies-qa.it.helsinki.fi/ohjeet/
