### PR TITLE
HUB-757 & HUB-774: Degree programme selection accessibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
-
+* HUB-757 & HUB-774 - Improved accessibility for degree programme selection.
 
 
 ## 1.51

--- a/modules/uhsg_search/js/uhsgSearch.js
+++ b/modules/uhsg_search/js/uhsgSearch.js
@@ -1,5 +1,6 @@
 (function ($) {
   'use strict';
+
   Drupal.behaviors.requireSearchText = {
     attach: function (context, settings) {
       var self = this;
@@ -7,25 +8,34 @@
       var searchButton = $('#edit-submit-search');
 
       if (!searchField.val()) {
-        searchButton.prop('disabled', true);
+        searchButton.prop('aria-disabled', true);
       }
 
-      searchField.keyup(function(e) {
+      searchButton.on('click', function(e) {
+        self.handleSubmit(e, searchField, searchButton);
+      });
+
+      searchField.on('keyup', function(e) {
         self.handleKeyUp(e, searchField, searchButton);
       });
     },
 
-    handleKeyUp: function(e, searchField, searchButton) {
+    handleSubmit: function(e, searchField, searchButton) {
       var empty = !searchField.val();
-      searchButton.prop('disabled', empty);
-      if (empty && e.which == 13) {
+      if (empty) {
         var originalPlaceholder = searchField.prop('placeholder');
         searchField.prop('placeholder', Drupal.t('Required field'));
         setTimeout(function () {
           searchField.prop('placeholder', originalPlaceholder);
         }, 1000);
       }
+    },
+
+    handleKeyUp: function(e, searchField, searchButton) {
+      var empty = !searchField.val();
+      searchButton.prop('aria-disabled', empty);
       searchField.val(searchField.val().toLowerCase());
     }
   }
+
 }(jQuery));

--- a/modules/uhsg_search/uhsg_search.module
+++ b/modules/uhsg_search/uhsg_search.module
@@ -20,6 +20,7 @@ function uhsg_search_form_views_exposed_form_alter(&$form, FormStateInterface $f
     $form['search_api_fulltext']['#attributes']['class'][] = 'search-form__input';
     $form['search_api_fulltext']['#attributes']['required'] = '';
     $form['actions']['submit']['#attributes']['class'][] = 'search-form__submit';
+    $form['actions']['submit']['#attributes']['aria-label'] = t('Search');
     $form['actions']['submit']['#value'] = "\u{EA35}";
   }
 }

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -3429,7 +3429,7 @@ img {
   title: Headings
   template: 3_1_headings
 */
-h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, h5, h6 {
+h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h4, h5, h6 {
   font-family: 'Open Sans', Helvetica, Arial, sans-serif;
   color: #222;
   letter-spacing: -0.05em;
@@ -3439,12 +3439,12 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, h5
   word-wrap: break-word;
 }
 
-h1 a, h2 a, .h2 a, h3 a, .h3 a, h4 a, legend a, .logo-block__content .logo-block__sitename a, h5 a, h6 a {
+h1 a, h2 a, .h2 a, h3 a, .h3 a, h4 a, legend a, .logo-block__content .logo-block__sitename a, .h4 a, h5 a, h6 a {
   color: inherit;
   text-decoration: none;
 }
 
-h1 a:hover, h2 a:hover, .h2 a:hover, h3 a:hover, .h3 a:hover, h4 a:hover, legend a:hover, .logo-block__content .logo-block__sitename a:hover, h5 a:hover, h6 a:hover {
+h1 a:hover, h2 a:hover, .h2 a:hover, h3 a:hover, .h3 a:hover, h4 a:hover, legend a:hover, .logo-block__content .logo-block__sitename a:hover, .h4 a:hover, h5 a:hover, h6 a:hover {
   color: inherit;
   cursor: pointer;
 }
@@ -3483,12 +3483,12 @@ h3, .h3 {
   }
 }
 
-h4, legend, .logo-block__content .logo-block__sitename {
+h4, legend, .logo-block__content .logo-block__sitename, .h4 {
   font-size: 1.25rem;
 }
 
 @media (max-width: 48em) {
-  h4, legend, .logo-block__content .logo-block__sitename {
+  h4, legend, .logo-block__content .logo-block__sitename, .h4 {
     font-size: 1.42857rem;
   }
 }
@@ -7820,7 +7820,7 @@ ul.pager > li.pager__page a {
   position: absolute;
 }
 
-.textarea h1, .textarea h2, .textarea .h2, .textarea h3, .textarea .h3, .textarea h4, .textarea legend, .textarea .logo-block__content .logo-block__sitename, .logo-block__content .textarea .logo-block__sitename, .textarea h5, .textarea h6,
+.textarea h1, .textarea h2, .textarea .h2, .textarea h3, .textarea .h3, .textarea h4, .textarea legend, .textarea .logo-block__content .logo-block__sitename, .logo-block__content .textarea .logo-block__sitename, .textarea .h4, .textarea h5, .textarea h6,
 .textarea-ingress h1,
 .textarea-ingress h2,
 .textarea-ingress .h2,
@@ -7830,12 +7830,13 @@ ul.pager > li.pager__page a {
 .textarea-ingress legend,
 .textarea-ingress .logo-block__content .logo-block__sitename,
 .logo-block__content .textarea-ingress .logo-block__sitename,
+.textarea-ingress .h4,
 .textarea-ingress h5,
 .textarea-ingress h6 {
   margin-top: 32px;
 }
 
-.textarea h1:first-child, .textarea h2:first-child, .textarea .h2:first-child, .textarea h3:first-child, .textarea .h3:first-child, .textarea h4:first-child, .textarea legend:first-child, .textarea .logo-block__content .logo-block__sitename:first-child, .logo-block__content .textarea .logo-block__sitename:first-child, .textarea h5:first-child, .textarea h6:first-child,
+.textarea h1:first-child, .textarea h2:first-child, .textarea .h2:first-child, .textarea h3:first-child, .textarea .h3:first-child, .textarea h4:first-child, .textarea legend:first-child, .textarea .logo-block__content .logo-block__sitename:first-child, .logo-block__content .textarea .logo-block__sitename:first-child, .textarea .h4:first-child, .textarea h5:first-child, .textarea h6:first-child,
 .textarea-ingress h1:first-child,
 .textarea-ingress h2:first-child,
 .textarea-ingress .h2:first-child,
@@ -7845,6 +7846,7 @@ ul.pager > li.pager__page a {
 .textarea-ingress legend:first-child,
 .textarea-ingress .logo-block__content .logo-block__sitename:first-child,
 .logo-block__content .textarea-ingress .logo-block__sitename:first-child,
+.textarea-ingress .h4:first-child,
 .textarea-ingress h5:first-child,
 .textarea-ingress h6:first-child {
   margin-top: 0;
@@ -9050,7 +9052,8 @@ li.avatar.avatar--default img {
 .degree-programme-switcher .degree-programme-switcher__dropdown > h4,
 .degree-programme-switcher .degree-programme-switcher__dropdown > legend,
 .degree-programme-switcher .logo-block__content .degree-programme-switcher__dropdown > .logo-block__sitename,
-.logo-block__content .degree-programme-switcher .degree-programme-switcher__dropdown > .logo-block__sitename {
+.logo-block__content .degree-programme-switcher .degree-programme-switcher__dropdown > .logo-block__sitename,
+.degree-programme-switcher .degree-programme-switcher__dropdown > .h4 {
   -ms-flex-negative: 0;
       flex-shrink: 0;
 }
@@ -9696,7 +9699,7 @@ input[type="submit"].button--reset + i {
           animation: icon-spin 2s infinite linear;
 }
 
-h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename,
+h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h4,
 .box-story__content {
   -webkit-hyphens: auto;
   -ms-hyphens: auto;
@@ -9717,6 +9720,10 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename,
 }
 
 .h3 {
+  text-transform: none;
+}
+
+.h4 {
   text-transform: none;
 }
 
@@ -9872,7 +9879,8 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename,
 .other-education-provider-switcher .other-education-provider-switcher__dropdown > h4,
 .other-education-provider-switcher .other-education-provider-switcher__dropdown > legend,
 .other-education-provider-switcher .logo-block__content .other-education-provider-switcher__dropdown > .logo-block__sitename,
-.logo-block__content .other-education-provider-switcher .other-education-provider-switcher__dropdown > .logo-block__sitename {
+.logo-block__content .other-education-provider-switcher .other-education-provider-switcher__dropdown > .logo-block__sitename,
+.other-education-provider-switcher .other-education-provider-switcher__dropdown > .h4 {
   -ms-flex-negative: 0;
       flex-shrink: 0;
 }

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8882,6 +8882,7 @@ li.avatar.avatar--default img {
 }
 
 .degree-programme-switcher .degree-programme-switcher__header {
+  background-color: #FFF;
   border-radius: 0;
   border: 1px solid #979797;
   outline-color: rgba(16, 126, 171, 0);
@@ -8906,8 +8907,9 @@ li.avatar.avatar--default img {
       -ms-flex-align: center;
           align-items: center;
   height: 3rem;
-  -webkit-box-sizing: content-box;
-          box-sizing: content-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  width: 100%;
 }
 
 .degree-programme-switcher .degree-programme-switcher__header:focus {
@@ -9742,6 +9744,7 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
 }
 
 .other-education-provider-switcher .other-education-provider-switcher__header {
+  background-color: #FFF;
   border-radius: 0;
   border: 1px solid #979797;
   outline-color: rgba(16, 126, 171, 0);
@@ -9766,8 +9769,9 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
       -ms-flex-align: center;
           align-items: center;
   height: 3rem;
-  -webkit-box-sizing: content-box;
-          box-sizing: content-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  width: 100%;
 }
 
 .other-education-provider-switcher .other-education-provider-switcher__header:focus {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8878,7 +8878,7 @@ li.avatar.avatar--default img {
   -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column;
-  padding-bottom: 2em;
+  padding-bottom: 0.5em;
 }
 
 .degree-programme-switcher .degree-programme-switcher__header {
@@ -8966,25 +8966,6 @@ li.avatar.avatar--default img {
   background: #FFF;
 }
 
-.degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content {
-  overflow-y: scroll;
-  scrollbar-face-color: #107EAB;
-  scrollbar-track-color: #F8F8F8;
-}
-
-.degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content::-webkit-scrollbar {
-  width: 0.5em;
-  height: 0.5em;
-}
-
-.degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content::-webkit-scrollbar-thumb {
-  background: #107EAB;
-}
-
-.degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content::-webkit-scrollbar-track {
-  background: #F8F8F8;
-}
-
 .degree-programme-switcher .degree-programme-switcher__dropdown .view-degree-programmes .view-content > div {
   -ms-flex-negative: 0;
       flex-shrink: 0;
@@ -9069,7 +9050,6 @@ li.avatar.avatar--default img {
       -ms-flex-direction: column;
           flex-direction: column;
   width: 100%;
-  min-height: 1px;
 }
 
 .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
@@ -9106,15 +9086,32 @@ li.avatar.avatar--default img {
   left: 0;
   height: 100%;
   width: 100%;
+  padding-bottom: 0;
 }
 
 .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
+  overflow-y: scroll;
+  scrollbar-face-color: #107EAB;
+  scrollbar-track-color: #F8F8F8;
   -webkit-transform: none;
       -ms-transform: none;
           transform: none;
   height: auto;
   opacity: 1;
   padding: 1em 1em 0 1em;
+}
+
+.degree-programme-switcher.collapsed .degree-programme-switcher__dropdown::-webkit-scrollbar {
+  width: 0.5em;
+  height: 0.5em;
+}
+
+.degree-programme-switcher.collapsed .degree-programme-switcher__dropdown::-webkit-scrollbar-thumb {
+  background: #107EAB;
+}
+
+.degree-programme-switcher.collapsed .degree-programme-switcher__dropdown::-webkit-scrollbar-track {
+  background: #F8F8F8;
 }
 
 .degree-programme-switcher.collapsed .degree-programme-switcher__header {
@@ -9142,12 +9139,32 @@ li.avatar.avatar--default img {
   .degree-programme-switcher.collapsed {
     height: auto;
     position: relative;
+    padding-bottom: 0.5em;
   }
   .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
+    overflow-y: auto;
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
     padding: 2em;
+  }
+  .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown .view-degree-programmes .view-content {
+    overflow-y: scroll;
+    scrollbar-face-color: #107EAB;
+    scrollbar-track-color: #F8F8F8;
+  }
+  .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown .view-degree-programmes .view-content::-webkit-scrollbar {
+    width: 0.5em;
+    height: 0.5em;
+  }
+  .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown .view-degree-programmes .view-content::-webkit-scrollbar-thumb {
+    background: #107EAB;
+  }
+  .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown .view-degree-programmes .view-content::-webkit-scrollbar-track {
+    background: #F8F8F8;
+  }
+  .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown div {
+    min-height: 1px;
   }
 }
 
@@ -9828,25 +9845,6 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
   background: #FFF;
 }
 
-.other-education-provider-switcher .other-education-provider-switcher__dropdown .view-other-education-providers .view-content {
-  overflow-y: scroll;
-  scrollbar-face-color: #107EAB;
-  scrollbar-track-color: #F8F8F8;
-}
-
-.other-education-provider-switcher .other-education-provider-switcher__dropdown .view-other-education-providers .view-content::-webkit-scrollbar {
-  width: 0.5em;
-  height: 0.5em;
-}
-
-.other-education-provider-switcher .other-education-provider-switcher__dropdown .view-other-education-providers .view-content::-webkit-scrollbar-thumb {
-  background: #107EAB;
-}
-
-.other-education-provider-switcher .other-education-provider-switcher__dropdown .view-other-education-providers .view-content::-webkit-scrollbar-track {
-  background: #F8F8F8;
-}
-
 .other-education-provider-switcher .other-education-provider-switcher__dropdown .view-other-education-providers .view-content > div {
   -ms-flex-negative: 0;
       flex-shrink: 0;
@@ -9898,7 +9896,6 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
       -ms-flex-direction: column;
           flex-direction: column;
   width: 100%;
-  min-height: 1px;
 }
 
 .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown {
@@ -9915,15 +9912,32 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
   left: 0;
   height: 100%;
   width: 100%;
+  padding-bottom: 0;
 }
 
 .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown {
+  overflow-y: scroll;
+  scrollbar-face-color: #107EAB;
+  scrollbar-track-color: #F8F8F8;
   -webkit-transform: none;
       -ms-transform: none;
           transform: none;
   height: auto;
   opacity: 1;
   padding: 1em 1em 0 1em;
+}
+
+.other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown::-webkit-scrollbar {
+  width: 0.5em;
+  height: 0.5em;
+}
+
+.other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown::-webkit-scrollbar-thumb {
+  background: #107EAB;
+}
+
+.other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown::-webkit-scrollbar-track {
+  background: #F8F8F8;
 }
 
 .other-education-provider-switcher.collapsed .other-education-provider-switcher__header {
@@ -9951,12 +9965,32 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
   .other-education-provider-switcher.collapsed {
     height: auto;
     position: relative;
+    padding-bottom: 2em;
   }
   .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown {
+    overflow-y: auto;
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
     padding: 0 2em 2em 2em;
+  }
+  .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown .view-other-education-providers .view-content {
+    overflow-y: scroll;
+    scrollbar-face-color: #107EAB;
+    scrollbar-track-color: #F8F8F8;
+  }
+  .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown .view-other-education-providers .view-content::-webkit-scrollbar {
+    width: 0.5em;
+    height: 0.5em;
+  }
+  .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown .view-other-education-providers .view-content::-webkit-scrollbar-thumb {
+    background: #107EAB;
+  }
+  .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown .view-other-education-providers .view-content::-webkit-scrollbar-track {
+    background: #F8F8F8;
+  }
+  .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown div {
+    min-height: 1px;
   }
 }
 
@@ -10127,10 +10161,6 @@ ul.pager > li a:focus {
 .view-search #edit-submit-search[disabled], .view-search #edit-submit-search[disabled]:active, .view-search #edit-submit-search[disabled]:focus, .view-search #edit-submit-search[disabled]:hover {
   color: #979797;
   background-color: transparent;
-}
-
-.view-search .degree-programme-switcher {
-  padding-bottom: 0.5em;
 }
 
 .ui-autocomplete {

--- a/themes/uhsg_theme/js/degreeProgrammeFilter.js
+++ b/themes/uhsg_theme/js/degreeProgrammeFilter.js
@@ -11,6 +11,7 @@
       container: '',
       item: '',
       groupingTitle: '',
+      ariaLive: '',
       charCount: 2
     }, options);
 
@@ -34,6 +35,9 @@
           }
         });
 
+        // Notify assistive technologies of current result count.
+        var count =  $(opt.item, opt.container).not(':hidden').length;
+        $(opt.ariaLive, opt.container).text(Drupal.t('Showing @count programmes.', {'@count': count}));
       });
     });
   };

--- a/themes/uhsg_theme/js/degreeProgrammeFilter.js
+++ b/themes/uhsg_theme/js/degreeProgrammeFilter.js
@@ -37,7 +37,7 @@
 
         // Notify assistive technologies of current result count.
         var count =  $(opt.item, opt.container).not(':hidden').length;
-        $(opt.ariaLive, opt.container).text(Drupal.t('Showing @count programmes.', {'@count': count}));
+        $(opt.ariaLive, opt.container).text(Drupal.t('Showing @count degree programmes.', {'@count': count}));
       });
     });
   };

--- a/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
+++ b/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
@@ -46,9 +46,10 @@
 
       // Apply view filtering to input
       filterInput.degreeProgrammeFilter({
-        container: '.view-degree-programmes',
+        container: '.degree-programme-switcher__list',
         item: '.list-of-links__link',
-        groupingTitle: '.view-subtitle'
+        groupingTitle: '.view-subtitle',
+        ariaLive: '.degree-programme-switcher__filter-messages',
       });
 
     },

--- a/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
+++ b/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
@@ -1,5 +1,6 @@
 (function ($) {
   'use strict';
+
   Drupal.behaviors.degreeProgrammeSwitcher = {
     attach: function (context, settings) {
       var triggerToggle = this.triggerToggle;
@@ -7,6 +8,7 @@
       var container = $('.degree-programme-switcher');
       var header = $('.degree-programme-switcher__header', degreeProgrammeSwitcher);
       var toggle = $('.degree-programme-switcher__toggle', degreeProgrammeSwitcher);
+      var dropdown = $('.degree-programme-switcher__dropdown', degreeProgrammeSwitcher);
       var filterInput = $('.degree-programme-switcher__filter input', degreeProgrammeSwitcher);
       var toggleClass = 'collapsed';
       var toggleIconClosed = 'icon--caret-down';
@@ -16,10 +18,7 @@
       // Toggle collapsed when click or keypress on header
       header.once().on({
         click: function (event) {
-          triggerToggle(event, container, toggleClass, toggle, toggleIconClosed, toggleIconOpen, breakpoints, filterInput);
-        },
-        keypress: function (event) {
-          triggerToggle(event, container, toggleClass, toggle, toggleIconClosed, toggleIconOpen, breakpoints, filterInput);
+          triggerToggle(event, container, header, dropdown, toggleClass, toggle, toggleIconClosed, toggleIconOpen, breakpoints, filterInput);
         }
       });
 
@@ -54,19 +53,26 @@
 
     },
 
-    triggerToggle: function (event, container, toggleClass, toggle, toggleIconClosed, toggleIconOpen, breakpoints, filterInput) {
-      // If key is not TAB (fix for Firefox 60.x.xesr).
-      if (event.keyCode != 9) {
-        event.preventDefault();
-        container.toggleClass(toggleClass);
-        $('body').toggleClass('no-scroll-mobile');
-        toggle.toggleClass(toggleIconClosed);
-        toggle.toggleClass(toggleIconOpen);
+    triggerToggle: function (event, container, header, dropdown, toggleClass, toggle, toggleIconClosed, toggleIconOpen, breakpoints, filterInput) {
+      event.preventDefault();
+      container.toggleClass(toggleClass);
+      $('body').toggleClass('no-scroll-mobile');
+      toggle.toggleClass(toggleIconClosed);
+      toggle.toggleClass(toggleIconOpen);
 
-        if (window.matchMedia(breakpoints['small']).matches) {
-          filterInput.focus();
-        }
+      if (container.hasClass(toggleClass)) {
+        header.attr('aria-expanded', 'true');
+        dropdown.attr('hidden', null);
+      }
+      else {
+        header.attr('aria-expanded', 'false');
+        dropdown.attr('hidden', '');
+      }
+
+      if (window.matchMedia(breakpoints['small']).matches) {
+        filterInput.focus();
       }
     }
   };
+
 }(jQuery));

--- a/themes/uhsg_theme/js/otherEducationProviderSwitcher.js
+++ b/themes/uhsg_theme/js/otherEducationProviderSwitcher.js
@@ -7,6 +7,7 @@
       var container = $('.other-education-provider-switcher');
       var header = $('.other-education-provider-switcher__header', otherEducationProviderSwitcher);
       var toggle = $('.other-education-provider-switcher__toggle', otherEducationProviderSwitcher);
+      var dropdown = $('.other-education-provider-switcher__dropdown', otherEducationProviderSwitcher);
       var toggleClass = 'collapsed';
       var toggleIconClosed = 'icon--caret-down';
       var toggleIconOpen = 'icon--caret-up';
@@ -14,10 +15,7 @@
       // Toggle collapsed when click or keypress on header
       header.once().on({
         click: function (event) {
-          triggerToggle(event, container, toggleClass, toggle, toggleIconClosed, toggleIconOpen);
-        },
-        keypress: function (event) {
-          triggerToggle(event, container, toggleClass, toggle, toggleIconClosed, toggleIconOpen);
+          triggerToggle(event, container, header, dropdown, toggleClass, toggle, toggleIconClosed, toggleIconOpen);
         }
       });
 
@@ -33,12 +31,21 @@
       });
     },
 
-    triggerToggle: function (event, container, toggleClass, toggle, toggleIconClosed, toggleIconOpen) {
+    triggerToggle: function (event, container, header, dropdown, toggleClass, toggle, toggleIconClosed, toggleIconOpen) {
       event.preventDefault();
       container.toggleClass(toggleClass);
       $('body').toggleClass('no-scroll-mobile');
       toggle.toggleClass(toggleIconClosed);
       toggle.toggleClass(toggleIconOpen);
+
+      if (container.hasClass(toggleClass)) {
+        header.attr('aria-expanded', 'true');
+        dropdown.attr('hidden', null);
+      }
+      else {
+        header.attr('aria-expanded', 'false');
+        dropdown.attr('hidden', '');
+      }
     }
   };
 }(jQuery));

--- a/themes/uhsg_theme/sass/components/_degree-programme-switcher.scss
+++ b/themes/uhsg_theme/sass/components/_degree-programme-switcher.scss
@@ -4,7 +4,8 @@
   background: $white;
   display: flex;
   flex-direction: column;
-  padding-bottom: 2em;
+  padding-bottom: 0.5em;
+
   .degree-programme-switcher__header {
     background-color: $white;
     border-radius: 0;
@@ -62,7 +63,6 @@
     background: $white;
     .view-degree-programmes {
       .view-content {
-        @include scrollbar;
         > div {
           flex-shrink: 0;
         }
@@ -118,7 +118,6 @@
       display: flex;
       flex-direction: column;
       width: 100%;
-      min-height: 1px;
     }
   }
   // Display when open.
@@ -149,7 +148,10 @@
     left: 0;
     height: 100%;
     width: 100%;
+    padding-bottom: 0;
+
     .degree-programme-switcher__dropdown {
+      @include scrollbar;
       transform: none;
       height: auto;
       opacity: 1;
@@ -178,9 +180,22 @@
     &.collapsed {
       height: auto;
       position: relative;
+      padding-bottom: 0.5em;
+
       .degree-programme-switcher__dropdown {
+        overflow-y: auto;
         display: flex;
         padding: 2em;
+
+        .view-degree-programmes {
+          .view-content {
+            @include scrollbar;
+          }
+        }
+
+        div {
+          min-height: 1px;
+        }
       }
     }
   }

--- a/themes/uhsg_theme/sass/components/_degree-programme-switcher.scss
+++ b/themes/uhsg_theme/sass/components/_degree-programme-switcher.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   padding-bottom: 2em;
   .degree-programme-switcher__header {
+    background-color: $white;
     border-radius: 0;
     border: 1px solid $silver;
     outline-color: rgba($blue, 0);
@@ -22,7 +23,8 @@
     justify-content: space-between;
     align-items: center;
     height: 3rem;
-    box-sizing: content-box;
+    box-sizing: border-box;
+    width: 100%;
 
     &:focus {
       outline-color: $blue;

--- a/themes/uhsg_theme/sass/components/_misc.scss
+++ b/themes/uhsg_theme/sass/components/_misc.scss
@@ -38,3 +38,8 @@ h1, h2, h3, h4,
   @extend h3;
   text-transform: none;
 }
+
+.h4 {
+  @extend h4;
+  text-transform: none;
+}

--- a/themes/uhsg_theme/sass/components/_other-education-provider-switcher.scss
+++ b/themes/uhsg_theme/sass/components/_other-education-provider-switcher.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   padding-bottom: 2em;
   .other-education-provider-switcher__header {
+    background-color: $white;
     border-radius: 0;
     border: 1px solid $silver;
     outline-color: rgba($blue, 0);
@@ -22,7 +23,8 @@
     justify-content: space-between;
     align-items: center;
     height: 3rem;
-    box-sizing: content-box;
+    box-sizing: border-box;
+    width: 100%;
 
     &:focus {
       outline-color: $blue;

--- a/themes/uhsg_theme/sass/components/_other-education-provider-switcher.scss
+++ b/themes/uhsg_theme/sass/components/_other-education-provider-switcher.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   padding-bottom: 2em;
+
   .other-education-provider-switcher__header {
     background-color: $white;
     border-radius: 0;
@@ -62,7 +63,6 @@
     background: $white;
     .view-other-education-providers {
       .view-content {
-        @include scrollbar;
         > div {
           flex-shrink: 0;
         }
@@ -93,7 +93,6 @@
       display: flex;
       flex-direction: column;
       width: 100%;
-      min-height: 1px;
     }
   }
   // Display when open.
@@ -110,7 +109,10 @@
     left: 0;
     height: 100%;
     width: 100%;
+    padding-bottom: 0;
+
     .other-education-provider-switcher__dropdown {
+      @include scrollbar;
       transform: none;
       height: auto;
       opacity: 1;
@@ -139,9 +141,22 @@
     &.collapsed {
       height: auto;
       position: relative;
+      padding-bottom: 2em;
+
       .other-education-provider-switcher__dropdown {
+        overflow-y: auto;
         display: flex;
         padding: 0 2em 2em 2em;
+
+        .view-other-education-providers {
+          .view-content {
+            @include scrollbar;
+          }
+        }
+
+        div {
+          min-height: 1px;
+        }
       }
     }
   }

--- a/themes/uhsg_theme/sass/components/_search.scss
+++ b/themes/uhsg_theme/sass/components/_search.scss
@@ -68,9 +68,6 @@
       background-color: transparent;
     }
   }
-  .degree-programme-switcher {
-    padding-bottom: 0.5em;
-  }
 }
 
 .ui-autocomplete {

--- a/themes/uhsg_theme/templates/block/block--views-block--degree-programmes-block-1.html.twig
+++ b/themes/uhsg_theme/templates/block/block--views-block--degree-programmes-block-1.html.twig
@@ -49,15 +49,28 @@
        hidden="">
     <h2 class="h4">{{ 'Search for degree programme'|trans }}</h2>
     <div class="degree-programme-switcher__filter tube">
-      <label for="filter">{{ 'Name of degree programme'|trans }}</label>
-      <input type="text" name="filter" placeholder="{{ 'Name of degree programme'|trans }}" class="search-form__input">
+      <label for="filter">{{ 'Search for degree programme by name or part of the name'|trans }}</label>
+      <input type="text"
+             name="filter"
+             placeholder="{{ 'Search for degree programme by name or part of the name'|trans }}"
+             class="search-form__input"
+             aria-controls="degree-programme-switcher-programmes-list-1"
+             aria-describedby="degree-programme-switcher-filter-description-1">
+      <div id="degree-programme-switcher-filter-description-1" class="description visually-hidden">
+        {{ 'When you search for a degree programme by name or by part of the name the options in the list of degree programmes below the search field is narrowed down. After this you have to choose the degree programme from the list.'|trans }}
+      </div>
       <i class="icon--search"></i>
     </div>
-    {% block content %}
-      {{ content }}
-    {% endblock %}
+
+    <div class="degree-programme-switcher__list" role="region" id="degree-programme-switcher-programmes-list-1">
+      <div class="degree-programme-switcher__filter-messages visually-hidden" aria-live="assertive"></div>
+      {% block content %}
+        {{ content }}
+      {% endblock %}
+    </div>
+
     {% if label %}
-      {{ link('Reset'|trans , reset_link.link, {'class': reset_link.classes }) }}
+      {{ link('Clear the selection'|trans , reset_link.link, {'class': reset_link.classes }) }}
     {% endif %}
   </div>
 </div>

--- a/themes/uhsg_theme/templates/block/block--views-block--degree-programmes-block-1.html.twig
+++ b/themes/uhsg_theme/templates/block/block--views-block--degree-programmes-block-1.html.twig
@@ -31,13 +31,13 @@
 <div class="degree-programme-switcher search-form">
   <label> {{ 'Select degree programme'|trans }} </label>
   <div class="degree-programme-switcher__header" tabindex="0">
-    <h4 class="degree-programme-switcher__title" data-degree-programme-code="{{ code }}">
+    <div class="h4 degree-programme-switcher__title" data-degree-programme-code="{{ code }}">
       {{ label }}
-    </h4>
+    </div>
     <span class="degree-programme-switcher__toggle icon--caret-down" />
   </div>
   <div class="degree-programme-switcher__dropdown">
-    <h4> {{ 'Search for degree programme'|trans }}</h4>
+    <h2 class="h4">{{ 'Search for degree programme'|trans }}</h2>
     <div class="degree-programme-switcher__filter tube">
       <label for="filter">{{ 'Name of degree programme'|trans }}</label>
       <input type="text" name="filter" placeholder="{{ 'Name of degree programme'|trans }}" class="search-form__input">

--- a/themes/uhsg_theme/templates/block/block--views-block--degree-programmes-block-1.html.twig
+++ b/themes/uhsg_theme/templates/block/block--views-block--degree-programmes-block-1.html.twig
@@ -30,13 +30,23 @@
 
 <div class="degree-programme-switcher search-form">
   <label> {{ 'Select degree programme'|trans }} </label>
-  <div class="degree-programme-switcher__header" tabindex="0">
+
+  <button class="degree-programme-switcher__header"
+          aria-expanded="false"
+          aria-controls="degree-programme-switcher-dropdown-1"
+          id="degree-programme-switcher-header-1"
+          tabindex="0">
     <div class="h4 degree-programme-switcher__title" data-degree-programme-code="{{ code }}">
       {{ label }}
     </div>
     <span class="degree-programme-switcher__toggle icon--caret-down" />
-  </div>
-  <div class="degree-programme-switcher__dropdown">
+  </button>
+
+  <div class="degree-programme-switcher__dropdown"
+       id="degree-programme-switcher-dropdown-1"
+       role="region"
+       aria-labelledby="degree-programme-switcher-header-1"
+       hidden="">
     <h2 class="h4">{{ 'Search for degree programme'|trans }}</h2>
     <div class="degree-programme-switcher__filter tube">
       <label for="filter">{{ 'Name of degree programme'|trans }}</label>

--- a/themes/uhsg_theme/templates/block/block--views-block--other-education-providers-block-1.html.twig
+++ b/themes/uhsg_theme/templates/block/block--views-block--other-education-providers-block-1.html.twig
@@ -29,13 +29,23 @@
 
 <div class="other-education-provider-switcher search-form">
   <label> {{ 'Select other education provider'|trans }} </label>
-  <div class="other-education-provider-switcher__header" tabindex="0">
+
+  <button class="other-education-provider-switcher__header"
+          aria-expanded="false"
+          aria-controls="other-education-provider-switcher-dropdown-1"
+          id="other-education-provider-switcher-header-1"
+          tabindex="0">
     <div class="h4 other-education-provider-switcher__title">
       {{ label }}
     </div>
     <span class="other-education-provider-switcher__toggle icon--caret-down" />
-  </div>
-  <div class="other-education-provider-switcher__dropdown">
+  </button>
+
+  <div class="other-education-provider-switcher__dropdown"
+       id="other-education-provider-switcher-dropdown-1"
+       role="region"
+       aria-labelledby="other-education-provider-switcher-header-1"
+       hidden="">
     {% block content %}
       {{ content }}
     {% endblock %}

--- a/themes/uhsg_theme/templates/block/block--views-block--other-education-providers-block-1.html.twig
+++ b/themes/uhsg_theme/templates/block/block--views-block--other-education-providers-block-1.html.twig
@@ -30,9 +30,9 @@
 <div class="other-education-provider-switcher search-form">
   <label> {{ 'Select other education provider'|trans }} </label>
   <div class="other-education-provider-switcher__header" tabindex="0">
-    <h4 class="other-education-provider-switcher__title">
+    <div class="h4 other-education-provider-switcher__title">
       {{ label }}
-    </h4>
+    </div>
     <span class="other-education-provider-switcher__toggle icon--caret-down" />
   </div>
   <div class="other-education-provider-switcher__dropdown">

--- a/themes/uhsg_theme/templates/block/block--views-block--other-education-providers-block-1.html.twig
+++ b/themes/uhsg_theme/templates/block/block--views-block--other-education-providers-block-1.html.twig
@@ -50,7 +50,7 @@
       {{ content }}
     {% endblock %}
     {% if label %}
-      {{ link('Reset'|trans , reset_link.link, {'class': reset_link.classes }) }}
+      {{ link('Clear the selection'|trans , reset_link.link, {'class': reset_link.classes }) }}
     {% endif %}
   </div>
 </div>

--- a/themes/uhsg_theme/templates/views/views-view-grouping.html.twig
+++ b/themes/uhsg_theme/templates/views/views-view-grouping.html.twig
@@ -17,7 +17,7 @@
 
 <div {{ attributes }}>
   {% if title %}
-    <h4 class="tube view-subtitle">{{ title }}</h4>
+    <h3 class="h4 tube view-subtitle">{{ title }}</h3>
   {% endif %}
   {{ content }}
 </div>

--- a/themes/uhsg_theme/templates/views/views-view-list.html.twig
+++ b/themes/uhsg_theme/templates/views/views-view-list.html.twig
@@ -20,7 +20,7 @@
   <div{{ attributes }}>
 {% endif %}
   {% if title %}
-    <h4 class="tube view-list-title view-subtitle">{{ title }}</h4>
+    <h3 class="h4 tube view-list-title view-subtitle">{{ title }}</h3>
   {% endif %}
 
   <{{ list.type }}{{ list.attributes }}>

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -191,7 +191,7 @@ msgstr "Hae koulutusohjelmaa nimellä tai nimen osalla"
 msgid "When you search for a degree programme by name or by part of the name the options in the list of degree programmes below the search field is narrowed down. After this you have to choose the degree programme from the list."
 msgstr "Kun haet koulutusohjelmaa nimellä tai nimen osalla hakukentän alapuolella olevan koulutusohjelmalistan vaihtoehdot rajautuvat. Valitse tämän jälkeen koulutusohjelma listasta."
 
-msgid "Showing @count programmes."
+msgid "Showing @count degree programmes."
 msgstr "Näytetään @count koulutusohjelmaa."
 
 msgid "Clear the selection"

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -185,6 +185,18 @@ msgstr "Vastaanottoaikoja ei voida näyttää. Yritä myöhemmin uudelleen."
 msgid "Instructions according to user group"
 msgstr "Ohjeet käyttäjäryhmittäin"
 
+msgid "Search for degree programme by name or part of the name"
+msgstr "Hae koulutusohjelmaa nimellä tai nimen osalla"
+
+msgid "When you search for a degree programme by name or by part of the name the options in the list of degree programmes below the search field is narrowed down. After this you have to choose the degree programme from the list."
+msgstr "Kun haet koulutusohjelmaa nimellä tai nimen osalla hakukentän alapuolella olevan koulutusohjelmalistan vaihtoehdot rajautuvat. Valitse tämän jälkeen koulutusohjelma listasta."
+
+msgid "Showing @count programmes."
+msgstr "Näytetään @count koulutusohjelmaa."
+
+msgid "Clear the selection"
+msgstr "Tyhjennä valinta"
+
 # Finnish translation of Scheduler (8.x-1.0)
 # Dev version translations can not be imported automatically.
 # These are copy & pasted from the official translation files.

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -182,6 +182,18 @@ msgstr "Mottagningstiderna kan inte visas. Försök pånytt senare."
 msgid "Instructions according to user group"
 msgstr "Instruktioner enligt användargrupp"
 
+msgid "Search for degree programme by name or part of the name"
+msgstr "Sök utbildningsprogram med namn eller del av namnet"
+
+msgid "When you search for a degree programme by name or by part of the name the options in the list of degree programmes below the search field is narrowed down. After this you have to choose the degree programme from the list."
+msgstr "När du söker utbildningsprogram med namn eller del av namnet begränsas alternativen i listan av utbildningsprogram under sökfältet. Välj efter detta utbildningsprogrammet i listan."
+
+msgid "Showing @count programmes."
+msgstr "Visar @count utbildningsprogram."
+
+msgid "Clear the selection"
+msgstr "Töm valet"
+
 # Swedish translation of Scheduler (8.x-1.0)
 # Dev version translations can not be imported automatically.
 # These are copy & pasted from the official translation files.

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -188,8 +188,8 @@ msgstr "Sök utbildningsprogram med namn eller del av namnet"
 msgid "When you search for a degree programme by name or by part of the name the options in the list of degree programmes below the search field is narrowed down. After this you have to choose the degree programme from the list."
 msgstr "När du söker utbildningsprogram med namn eller del av namnet begränsas alternativen i listan av utbildningsprogram under sökfältet. Välj efter detta utbildningsprogrammet i listan."
 
-msgid "Showing @count programmes."
-msgstr "Visar @count utbildningsprogram."
+msgid "Showing @count degree programmes."
+msgstr "Visas @count utbildningsprogram."
 
 msgid "Clear the selection"
 msgstr "Töm valet"


### PR DESCRIPTION
This PR fixes multiple accessibility issues in degree programme selection and site search form for both the student guide and teachers guide.

### HUB-757

- Proper semantic ordering of heading tags and removing heading tags where they were misleading for screen readers.
- Making the toggle element a button and adding aria-attributes to better inform screen readers of its state and relations.
- Improving the degree programme filtering input to better instruct screen reader users of what it does and how to use it by adding more informative labels and descriptions, and adding a aria-live region to inform of current result count.
- Improving the site search form by adding an aria-label to submit button for screen readers and allowing native browser validation for required keyword field (this will hopefully allow screen readers to properly inform the validation error if a form submit is attempted while the field is empty). 

### HUB-774

- Style updates to allow proper degree programme list browsing when zoom is at 400%.