### PR TITLE
HUB-772: Open university user group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
-
+* HUB-772 - New user group option 'Open University'.
 
 
 ## 1.51

--- a/config/sync/field.storage.node.field_user_group.yml
+++ b/config/sync/field.storage.node.field_user_group.yml
@@ -23,6 +23,9 @@ settings:
     -
       value: teachers
       label: Teachers
+    -
+      value: open_university
+      label: 'Open University'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/language/fi/field.storage.node.field_user_group.yml
+++ b/config/sync/language/fi/field.storage.node.field_user_group.yml
@@ -8,3 +8,5 @@ settings:
       label: 'Ammatillinen jatkokoulutus'
     -
       label: Opettajat
+    -
+      label: 'Avoin yliopisto'

--- a/config/sync/language/sv/field.storage.node.field_user_group.yml
+++ b/config/sync/language/sv/field.storage.node.field_user_group.yml
@@ -8,3 +8,5 @@ settings:
       label: 'Yrkesinriktad påbyggnadsutbildning'
     -
       label: Lärarna
+    -
+      label: 'Öppna universitetet'


### PR DESCRIPTION
This PR adds a new user group otion 'Open University' for Instructions, Themes and Bulletins. This is to allow open university to start adding help content to the site, so there's no need to make this change visible elsewhere on the site at this point.