### PR TITLE
HUB-779: Content table link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* HUB-779: Improved accessibility for content links when inside tables.
+
 ## 1.52
 Release date: 19.10.2020
 

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -10259,6 +10259,16 @@ ul.pager > li a:focus {
   text-decoration: underline;
 }
 
+.textarea table td a, .textarea table th a {
+  color: #0e688b;
+  text-decoration: underline;
+}
+
+.textarea table td a:hover, .textarea table th a:hover {
+  color: #005379;
+  text-decoration: underline;
+}
+
 .theme--box {
   -webkit-hyphens: auto;
   -ms-hyphens: auto;

--- a/themes/uhsg_theme/sass/components/_textarea.scss
+++ b/themes/uhsg_theme/sass/components/_textarea.scss
@@ -9,4 +9,18 @@
   a {
     text-decoration: underline;
   }
+
+  table {
+    td, th {
+      a {
+        color: $color-link;
+        text-decoration: underline;
+
+        &:hover {
+          color: $color-link-hover;
+          text-decoration: underline;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR updates styles for content links when inside tables to improve accessibility. These same changes were introduced for content area links in https://github.com/UH-StudentServices/student_guide/pull/351 but those changes didn't apply for links inside tables.