### PR TITLE
HUB-756: Degree programme selection - close when focus goes out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* HUB-756: Improving accessibility on degree programme selector.
+
 ## 1.52
 Release date: 19.10.2020
 

--- a/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
+++ b/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
@@ -23,8 +23,8 @@
         }
       });
 
-      // Close when clicking outside
-      $(document).once().on('click', function (e) {
+      // Close when clicking or focusing outside
+      $(document).once().on('click focusin', function (e) {
         var clickedOutside = $(e.target).parents(degreeProgrammeSwitcher).length === 0;
         if (container.hasClass(toggleClass) && clickedOutside) {
           container.removeClass(toggleClass);

--- a/themes/uhsg_theme/js/otherEducationProviderSwitcher.js
+++ b/themes/uhsg_theme/js/otherEducationProviderSwitcher.js
@@ -21,8 +21,8 @@
         }
       });
 
-      // Close when clicking outside
-      $(document).once().on('click', function (e) {
+      // Close when clicking or focusing outside
+      $(document).once().on('click focusin', function (e) {
         var clickedOutside = $(e.target).parents(otherEducationProviderSwitcher).length === 0;
         if (container.hasClass(toggleClass) && clickedOutside) {
           container.removeClass(toggleClass);


### PR DESCRIPTION
This PR updates the degree programme and other education provider selection elements to close when focus is set outside of them. This is to avoid a use case where a focused element is behind an open selection container as a result of keyboard navigation.