### PR TITLE
HUB-758: Paging a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: ??.??.????
 * HUB-772 - New user group option 'Open University'.
 * HUB-763 - Disabled tooltip.
 * HUB-779 - Improved accessibility for content links when inside tables.
+* HUB-758 - Improved accessibility for paging links.
 
 ## 1.52
 Release date: 19.10.2020

--- a/themes/uhsg_theme/templates/misc/pager.html.twig
+++ b/themes/uhsg_theme/templates/misc/pager.html.twig
@@ -50,7 +50,10 @@
       {% for key, item in items.pages %}
         {% if current == key %}
           <li class="pager__page">
-            <a href="#" class="button is-active">
+            <a href="#" class="button is-active" aria-current="page">
+              <span class="visually-hidden">
+                {{ 'Current page'|t }}
+              </span>
               {{- key -}}
             </a>
           </li>


### PR DESCRIPTION
This PR updates the pager markup with accessible indicators for the link pointing to current page.