### PR TITLE
HUB-762: Search result double links away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: ??.??.????
 * HUB-772 - New user group option 'Open University'.
 * HUB-763 - Disabled tooltip.
 * HUB-779 - Improved accessibility for content links when inside tables.
+* HUB-762 - Improved accessibility for search results.
 
 ## 1.52
 Release date: 19.10.2020

--- a/themes/uhsg_theme/templates/node/node--constrained.html.twig
+++ b/themes/uhsg_theme/templates/node/node--constrained.html.twig
@@ -101,6 +101,6 @@
     <a href="{{ url }}"> {{ label }} </a>
   </h3>
   <div class="box-story__content">
-    <a href="{{ url }}"> {{ body|striptags|raw }} </a>
+    {{ body|striptags|raw }}
   </div>
 </article>


### PR DESCRIPTION
This PR removes the link wrapper from search result ingress text. The title already has the link and having it on the ingress as well results in consecutive identical links which is misleading / confusing to many assistive technologies.