### PR TITLE
HUB-759: Language switcher a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* HUB-759 - Improved accessibility for language switcher.
 
 ## 1.53
 Release date: 27.10.2020

--- a/themes/uhsg_theme/uhsg_theme.theme
+++ b/themes/uhsg_theme/uhsg_theme.theme
@@ -61,6 +61,7 @@ function uhsg_theme_preprocess_links__language_block(&$variables) {
   foreach ($variables['links'] as $langcode => &$link) {
     // add classes for theming
     $link['link']['#options']['attributes']['class'][] = 'links__link theme-language';
+    $link['link']['#options']['attributes']['lang'] = $langcode;
     $link['link']['#title'] = new FormattableMarkup('<abbr title="@title">@langcode</abbr>', ['@title' => $link['link']['#title'], '@langcode' => $langcode]);
     // hide active language
     $active_language = Drupal::languageManager()->getCurrentLanguage()->getId();


### PR DESCRIPTION
This PR adds a `lang`-attribute to language switcher links for proper screen reader pronunciation.