### PR TITLE
HUB-748: Footer copyright year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: ??.??.????
 * HUB-784 - Improving accessibility on degree programme and other education provider selections.
 * HUB-759 - Improved accessibility for language switcher.
 * HUB-767 - Improved accessibility for video embeds.
+* HUB-748 - Updated footer copyright year.
 
 ## 1.53
 Release date: 27.10.2020

--- a/config/sync/language/fi/uhsg_service_provider_details.settings.yml
+++ b/config/sync/language/fi/uhsg_service_provider_details.settings.yml
@@ -1,6 +1,6 @@
 logo_text: 'Helsingin Yliopisto'
 logo_path: 'https://www.helsinki.fi/fi'
 home_path: 'http://student.helsinki.fi'
-copyright_text: '<p>© Hel­sin­gin yli­opis­to 2019</p>'
+copyright_text: '<p>© Hel­sin­gin yli­opis­to 2020</p>'
 contact_info: '<div class="logo-block__sitename">Hel­sin­gin yli­opis­to</div><p>PL 4 (Yliopistonkatu 3) 00014 Helsingin yliopisto</p><p>Puhelinvaihde: <a class="is-tel" href="tel:+3582941911">02941 911</a></p>'
 logo_title: 'Helsingin Yliopisto'

--- a/config/sync/language/sv/uhsg_service_provider_details.settings.yml
+++ b/config/sync/language/sv/uhsg_service_provider_details.settings.yml
@@ -1,6 +1,6 @@
 logo_text: 'Helsingfors universitet'
 logo_path: 'https://www.helsinki.fi/sv'
 home_path: 'http://student.helsinki.fi/se'
-copyright_text: '<p>© Helsingfors universitet 2019</p>'
+copyright_text: '<p>© Helsingfors universitet 2020</p>'
 contact_info: '<div class="logo-block__sitename">Helsing­fors uni­ver­si­tet</div><p>PB 4 (Universitetsgatan 3) 00014 Helsingfors universitet Finland</p><p> Växel: <a class="is-tel" href="tel:+3582941911">+358 (0) 2941 911</a></p>'
 logo_title: 'Helsingfors universitet'

--- a/config/sync/uhsg_service_provider_details.settings.yml
+++ b/config/sync/uhsg_service_provider_details.settings.yml
@@ -1,7 +1,7 @@
 logo_text: 'University of Helsinki'
 logo_path: 'https://www.helsinki.fi/en'
 home_path: 'http://student.helsinki.fi/en'
-copyright_text: '<p>© University of Helsinki 2019</p>'
+copyright_text: '<p>© University of Helsinki 2020</p>'
 contact_info: '<div class="logo-block__sitename">Uni­versity of Hel­sinki</div><p>P.O. Box 4 (Yliopistonkatu 3) 00014 University of Helsinki</p><p>Switchboard: <a class="is-tel" href="tel:+3582941911">+358 (0) 2941 911</a></p>'
 langcode: en
 _core:


### PR DESCRIPTION
This PR updates the footer copyright year to 2020 (yeah I know, better late than never 😄 ). This only affects the teachers guide as student guide has the obar.