### PR TITLE
HUB-789: Allow zip attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Release date: ??.??.????
 * HUB-759 - Improved accessibility for language switcher.
 * HUB-767 - Improved accessibility for video embeds.
 * HUB-748 - Updated footer copyright year.
+* HUB-789 - Allowing zip file content attachments.
 
 ## 1.53
 Release date: 27.10.2020

--- a/config/sync/editor.editor.filtered_html.yml
+++ b/config/sync/editor.editor.filtered_html.yml
@@ -12,7 +12,7 @@ third_party_settings:
     status: true
     scheme: public
     directory: inline-files
-    extensions: 'txt pdf docx xlsx jpg png gif tex'
+    extensions: 'txt pdf docx xlsx jpg png gif tex zip'
 format: filtered_html
 editor: ckeditor
 settings:


### PR DESCRIPTION
This PR adds `zip` to editor_file allowed extensions. This allows zip files to be uploaded as content attachments.