### PR TITLE
HUB-785: Degree programme and other education provider selection mobile a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release date: ??.??.????
 * HUB-789 - Allowing zip file content attachments.
 * HUB-788 - Modify pathauto settings to delete old alias.
 * HUB-780 - Added new user role 'Content owner'.
+* HUB-785 - Improved accessibility for degree programme and other education provider selections.
 
 ## 1.53
 Release date: 27.10.2020

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -9081,39 +9081,16 @@ li.avatar.avatar--default img {
 }
 
 .degree-programme-switcher.collapsed {
-  position: fixed;
   z-index: 102;
-  margin-top: 0;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  padding-bottom: 0;
 }
 
 .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
-  overflow-y: scroll;
-  scrollbar-face-color: #107EAB;
-  scrollbar-track-color: #F8F8F8;
   -webkit-transform: none;
       -ms-transform: none;
           transform: none;
   height: auto;
   opacity: 1;
   padding: 1em 1em 0 1em;
-}
-
-.degree-programme-switcher.collapsed .degree-programme-switcher__dropdown::-webkit-scrollbar {
-  width: 0.5em;
-  height: 0.5em;
-}
-
-.degree-programme-switcher.collapsed .degree-programme-switcher__dropdown::-webkit-scrollbar-thumb {
-  background: #107EAB;
-}
-
-.degree-programme-switcher.collapsed .degree-programme-switcher__dropdown::-webkit-scrollbar-track {
-  background: #F8F8F8;
 }
 
 .degree-programme-switcher.collapsed .degree-programme-switcher__header {
@@ -9144,7 +9121,6 @@ li.avatar.avatar--default img {
     padding-bottom: 0.5em;
   }
   .degree-programme-switcher.collapsed .degree-programme-switcher__dropdown {
-    overflow-y: auto;
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
@@ -9909,39 +9885,16 @@ h1, h2, .h2, h3, .h3, h4, legend, .logo-block__content .logo-block__sitename, .h
 }
 
 .other-education-provider-switcher.collapsed {
-  position: fixed;
   z-index: 102;
-  margin-top: 0;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  padding-bottom: 0;
 }
 
 .other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown {
-  overflow-y: scroll;
-  scrollbar-face-color: #107EAB;
-  scrollbar-track-color: #F8F8F8;
   -webkit-transform: none;
       -ms-transform: none;
           transform: none;
   height: auto;
   opacity: 1;
   padding: 1em 1em 0 1em;
-}
-
-.other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown::-webkit-scrollbar {
-  width: 0.5em;
-  height: 0.5em;
-}
-
-.other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown::-webkit-scrollbar-thumb {
-  background: #107EAB;
-}
-
-.other-education-provider-switcher.collapsed .other-education-provider-switcher__dropdown::-webkit-scrollbar-track {
-  background: #F8F8F8;
 }
 
 .other-education-provider-switcher.collapsed .other-education-provider-switcher__header {

--- a/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
+++ b/themes/uhsg_theme/js/degreeProgrammeSwitcher.js
@@ -25,10 +25,14 @@
 
       // Close when clicking or focusing outside
       $(document).once('degree_programme_switcher_focus_out').on('click focusin', function (e) {
+        // Let's not auto close on mobile viewports.
+        if (window.matchMedia(breakpoints['mobile']).matches) {	
+          return true;
+        }
+
         var clickedOutside = $(e.target).parents(degreeProgrammeSwitcher).length === 0;
         if (container.hasClass(toggleClass) && clickedOutside) {
           container.removeClass(toggleClass);
-          $('body').removeClass('no-scroll-mobile');
           toggle.toggleClass(toggleIconClosed);
           toggle.toggleClass(toggleIconOpen);
         }
@@ -66,7 +70,6 @@
     triggerToggle: function (event, container, header, dropdown, toggleClass, toggle, toggleIconClosed, toggleIconOpen, breakpoints, filterInput) {
       event.preventDefault();
       container.toggleClass(toggleClass);
-      $('body').toggleClass('no-scroll-mobile');
       toggle.toggleClass(toggleIconClosed);
       toggle.toggleClass(toggleIconOpen);
 

--- a/themes/uhsg_theme/js/otherEducationProviderSwitcher.js
+++ b/themes/uhsg_theme/js/otherEducationProviderSwitcher.js
@@ -12,6 +12,7 @@
       var toggleIconClosed = 'icon--caret-down';
       var toggleIconOpen = 'icon--caret-up';
       var resetButton = $('.button--reset', otherEducationProviderSwitcher);
+      var breakpoints = settings.breakpoints;
 
       // Toggle collapsed when click or keypress on header
       header.once().on({
@@ -22,10 +23,14 @@
 
       // Close when clicking or focusing outside
       $(document).once('other_education_provider_switcher_focus_out').on('click focusin', function (e) {
+        // Let's not auto close on mobile viewports.
+        if (window.matchMedia(breakpoints['mobile']).matches) {	
+          return true;
+        }
+
         var clickedOutside = $(e.target).parents(otherEducationProviderSwitcher).length === 0;
         if (container.hasClass(toggleClass) && clickedOutside) {
           container.removeClass(toggleClass);
-          $('body').removeClass('no-scroll-mobile');
           toggle.toggleClass(toggleIconClosed);
           toggle.toggleClass(toggleIconOpen);
         }
@@ -44,7 +49,6 @@
     triggerToggle: function (event, container, header, dropdown, toggleClass, toggle, toggleIconClosed, toggleIconOpen) {
       event.preventDefault();
       container.toggleClass(toggleClass);
-      $('body').toggleClass('no-scroll-mobile');
       toggle.toggleClass(toggleIconClosed);
       toggle.toggleClass(toggleIconOpen);
 

--- a/themes/uhsg_theme/sass/components/_degree-programme-switcher.scss
+++ b/themes/uhsg_theme/sass/components/_degree-programme-switcher.scss
@@ -142,22 +142,15 @@
     }
   }
   &.collapsed {
-    position: fixed;
     z-index: 102;
-    margin-top: 0;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    padding-bottom: 0;
 
     .degree-programme-switcher__dropdown {
-      @include scrollbar;
       transform: none;
       height: auto;
       opacity: 1;
       padding: 1em 1em 0 1em;
     }
+
     .degree-programme-switcher__header {
       border-bottom: 0;
     }
@@ -184,7 +177,6 @@
       padding-bottom: 0.5em;
 
       .degree-programme-switcher__dropdown {
-        overflow-y: auto;
         display: flex;
         padding: 2em;
 

--- a/themes/uhsg_theme/sass/components/_other-education-provider-switcher.scss
+++ b/themes/uhsg_theme/sass/components/_other-education-provider-switcher.scss
@@ -102,17 +102,9 @@
     }
   }
   &.collapsed {
-    position: fixed;
     z-index: 102;
-    margin-top: 0;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    padding-bottom: 0;
 
     .other-education-provider-switcher__dropdown {
-      @include scrollbar;
       transform: none;
       height: auto;
       opacity: 1;


### PR DESCRIPTION
This PR updates the way degree programme and other education provider (teachers guide) selections behave on **mobile**:

- Selection box no longer opens on top of content but instead is part of the page flow pushing the rest of the page content down - This overcomes a usability issue where screen reader navigation might end up focusing on an element behind the selection box (for example iOS + Safari + VoiceOver where normal focus event's aren't triggered so there's actually no way of detecting when that happens).
- Selection box is no longer automatically closed when focus or click is set outside of the box - This might cause a very confusing page scroll when the closing box changes the document height.