### PR TITLE
HUB-770: Responsive tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release date: ??.??.????
 * HUB-789 - Allowing zip file content attachments.
 * HUB-788 - Modify pathauto settings to delete old alias.
 * HUB-780 - Added new user role 'Content owner'.
+* HUB-770 - Improved accessibility for content tables.
 
 ## 1.53
 Release date: 27.10.2020

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "drupal/upgrade_status": "^2.9",
         "phpstan/phpstan": "0.12.42",
         "drupal/memcache": "^2.2",
-        "drupal/entity_browser": "^2.5"
+        "drupal/entity_browser": "^2.5",
+        "drupal/responsive_table_filter": "^1.2"
     },
     "repositories": {
         "0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f51eafdca93961e21b17050dd9cb6099",
+    "content-hash": "a19af7936a64ed680090ca79bc63cd21",
     "packages": [
         {
             "name": "UH-StudentServices/uh_courses_embed",
@@ -4216,6 +4216,50 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/responsive_table_filter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/responsive_table_filter.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/responsive_table_filter-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "27490864376f49f8809a3100807bfb97d3d8b59f"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1587719485",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                }
+            ],
+            "description": "Provides a text filter that wraps table tags with an figure element.",
+            "homepage": "https://www.drupal.org/project/responsive_table_filter",
+            "support": {
+                "source": "https://git.drupalcode.org/project/responsive_table_filter"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -63,6 +63,7 @@ module:
   purge_ui: 0
   redirect: 0
   responsive_image: 0
+  responsive_table_filter: 0
   rest: 0
   restui: 0
   samlauth: 0

--- a/config/sync/editor.editor.filtered_html.yml
+++ b/config/sync/editor.editor.filtered_html.yml
@@ -13,6 +13,7 @@ third_party_settings:
     scheme: public
     directory: inline-files
     extensions: 'txt pdf docx xlsx jpg png gif tex zip'
+    max_size: ''
 format: filtered_html
 editor: ckeditor
 settings:

--- a/config/sync/filter.format.filtered_html.yml
+++ b/config/sync/filter.format.filtered_html.yml
@@ -1,7 +1,9 @@
 uuid: 1c04dcc7-e281-404a-be63-38e8004c3ae3
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - responsive_table_filter
 name: 'Filtered html'
 format: filtered_html
 weight: 0
@@ -40,3 +42,11 @@ filters:
     status: true
     weight: 0
     settings: {  }
+  filter_responsive_table:
+    id: filter_responsive_table
+    provider: responsive_table_filter
+    status: true
+    weight: 0
+    settings:
+      wrapper_element: figure
+      wrapper_classes: responsive-figure-table

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -10315,6 +10315,11 @@ ul.pager > li a:focus {
   text-decoration: underline;
 }
 
+.textarea table td:first-child {
+  font-weight: 400;
+  font-style: normal;
+}
+
 .theme--box {
   -webkit-hyphens: auto;
   -ms-hyphens: auto;

--- a/themes/uhsg_theme/sass/components/_textarea.scss
+++ b/themes/uhsg_theme/sass/components/_textarea.scss
@@ -22,5 +22,11 @@
         }
       }
     }
+
+    td {
+      &:first-child {
+        @include font-weight-book;
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds a new contrib module `responsive_table_filter` and activates a new text format filter to wrap all content tables into a responsive container. This also removes the forced bold text on the first table column to not make it appear as a heading cell unless it actually is one.