### PR TITLE
HUB-828 - Fixing JSONAPI regression related to HUB-804

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.xx-dev
 Release date: ??.??.????
 
+* HUB-828 - Resolve JSONAPI node count regression
 
 
 ## 1.56

--- a/modules/uhsg_rest/src/Plugin/rest/resource/DegreeProgrammeResource.php
+++ b/modules/uhsg_rest/src/Plugin/rest/resource/DegreeProgrammeResource.php
@@ -157,8 +157,8 @@ class DegreeProgrammeResource extends ResourceBase {
         ->condition('field_news_degree_programme', $term->tid->value)
         ->condition('type', $content_type)
         ->condition('langcode', $languageCode)
+        ->condition('status', 1)
         ->accessCheck(false)
-        ->status(true)
         ->execute();
 
         if(count($nodes[$languageCode]) > 0) {

--- a/modules/uhsg_rest/src/Plugin/rest/resource/DegreeProgrammeResource.php
+++ b/modules/uhsg_rest/src/Plugin/rest/resource/DegreeProgrammeResource.php
@@ -96,6 +96,16 @@ class DegreeProgrammeResource extends ResourceBase {
     foreach ($degreeProgrammeTerms as $term) {
       $code = $term->get('field_code')->value;
       $name = $this->getNameTranslations($term);
+      // $degreeProgrammes[] = ['code' => $code, 'name' => $name];
+      // $this->getNodeCount() caused fatal errors on jsonapi anon page load,
+      // which is rather complex and misleading. In this case it's easiest
+      // to limit by removing access perm checks, which is ok in this case
+      // because its really only fetching a number.
+      //
+      // The problems complexity is best described by Lullabot:
+      // https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8
+      // However the simple access check fix is based on this thread:
+      // https://drupal.stackexchange.com/questions/251864/logicexception-the-controller-result-claims-to-be-providing-relevant-cache-meta
       $newsCount = $this->getNodeCount($term, "news");
       $contentCount = [
         'news' => $newsCount,
@@ -147,6 +157,7 @@ class DegreeProgrammeResource extends ResourceBase {
         ->condition('field_news_degree_programme', $term->tid->value)
         ->condition('type', $content_type)
         ->condition('langcode', $languageCode)
+        ->accessCheck(false)
         ->execute();
 
         if(count($nodes[$languageCode]) > 0) {

--- a/modules/uhsg_rest/src/Plugin/rest/resource/DegreeProgrammeResource.php
+++ b/modules/uhsg_rest/src/Plugin/rest/resource/DegreeProgrammeResource.php
@@ -158,6 +158,7 @@ class DegreeProgrammeResource extends ResourceBase {
         ->condition('type', $content_type)
         ->condition('langcode', $languageCode)
         ->accessCheck(false)
+        ->status(true)
         ->execute();
 
         if(count($nodes[$languageCode]) > 0) {


### PR DESCRIPTION
…ub.com/UH-StudentServices/student_guide/pull/383/files ).

Anonynous visitors would get a fatal error at https://studies.helsinki.fi/ohjeet/api/v1/degree-programme?_format=json :
LogicException: The controller result claims to be providing relevant cache metadata, but leaked metadata was detected. Please ensure you are not rendering content too early. Returned object class: Drupal\rest\ResourceResponse. in Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext() (line 154 of /var/www/html/build/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php).

Disablong access check permission is the simple fix here, and is secure because the query is only fetching node counts.

More info:
https://drupal.stackexchange.com/questions/251864/logicexception-the-controller-result-claims-to-be-providing-relevant-cache-meta
https://drupal.stackexchange.com/questions/258378/how-do-i-add-cacheablemetadata-to-an-array-im-returning-in-a-rest-resource
https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8