### PR TITLE
HUB-805: Revision lists fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
-
-
+* HUB-805 - Fixed a bug with the node revision list.
 
 ## 1.56
 Release date: 28.12.2020

--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,8 @@
             "drupal/core": {
                 "2791693-38": "https://www.drupal.org/files/issues/2019-03-16/2791693-38.patch",
                 "3101344-20": "https://www.drupal.org/files/issues/2020-02-12/translations_not_save_invalid_path-3101344-20.patch",
-                "2972308-41 - content_translation performance": "https://www.drupal.org/files/issues/2019-12-03/allow-users-to-translate-editable-content-2972308-41.patch"
+                "2972308-41 - content_translation performance": "https://www.drupal.org/files/issues/2019-12-03/allow-users-to-translate-editable-content-2972308-41.patch",
+                "3021671-7": "https://www.drupal.org/files/issues/2018-12-28/node_revisions_issue-3021671-07.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "965db57f8f2588ad53b199f51e3671da",
+    "content-hash": "b4faa4907078c29d21837cfe83d2ef41",
     "packages": [
         {
             "name": "UH-StudentServices/uh_courses_embed",
@@ -2299,7 +2299,8 @@
                 "patches_applied": {
                     "2791693-38": "https://www.drupal.org/files/issues/2019-03-16/2791693-38.patch",
                     "3101344-20": "https://www.drupal.org/files/issues/2020-02-12/translations_not_save_invalid_path-3101344-20.patch",
-                    "2972308-41 - content_translation performance": "https://www.drupal.org/files/issues/2019-12-03/allow-users-to-translate-editable-content-2972308-41.patch"
+                    "2972308-41 - content_translation performance": "https://www.drupal.org/files/issues/2019-12-03/allow-users-to-translate-editable-content-2972308-41.patch",
+                    "3021671-7": "https://www.drupal.org/files/issues/2018-12-28/node_revisions_issue-3021671-07.patch"
                 }
             },
             "autoload": {


### PR DESCRIPTION
This PR applies a Drupal core patch to fix a bug where the first item of all the Node revision list pages was always marked as the currently active version, making it impossible to open or revert those versions.