### PR TITLE
HUB-689: Obar container background color and height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Release date: ??.??.????
 * HUB-805 - Fixed a bug with the node revision list.
 * HUB-828 - Resolve JSONAPI node count regression.
+* HUB-689 - Updating obar container height and background color.
 
 ## 1.56
 Release date: 28.12.2020

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -9403,25 +9403,21 @@ input[type="submit"].button--reset + i {
 }
 
 #obar-header {
-  background: #222;
-  min-height: 195px;
+  background: #000;
 }
 
-@media (max-width: 48em) {
-  #obar-header {
-    min-height: 145px;
+#obar-header > header:empty {
+  min-height: 130px;
+}
+
+@media (min-width: 62.5em) {
+  #obar-header > header:empty {
+    min-height: 168px;
   }
 }
 
 #obar-footer {
-  background: #222;
-  min-height: 195px;
-}
-
-@media (max-width: 48em) {
-  #obar-footer {
-    min-height: 145px;
-  }
+  background: #000;
 }
 
 .list-of-links__compact .list-of-links__link {

--- a/themes/uhsg_theme/sass/components/_header_obar.scss
+++ b/themes/uhsg_theme/sass/components/_header_obar.scss
@@ -1,15 +1,15 @@
 #obar-header {
-  background: $black;
-  min-height: 195px;
-  @include breakpoint($mobile-only) {
-    min-height: 145px;
+  background: $obar-bg;
+
+  > header:empty {
+    min-height: 130px;
+
+    @include breakpoint($medium) {
+      min-height: 168px;
+    }
   }
 }
 
 #obar-footer {
-  background: $black;
-  min-height: 195px;
-  @include breakpoint($mobile-only) {
-    min-height: 145px;
-  }
+  background: $obar-bg;
 }

--- a/themes/uhsg_theme/sass/variables/_variables.scss
+++ b/themes/uhsg_theme/sass/variables/_variables.scss
@@ -4,3 +4,4 @@ $purple: #7b46a3;
 $color-link: #0e688b;
 $color-link-hover: #005379;
 $avatarbg: rgba($purple, .45);
+$obar-bg: #000;


### PR DESCRIPTION
This PR updates styles for the obar container:

- Update background color to match obar.
- Update container minimum height closer to current obar heights in different breakpoints. Also minimum height is now only active when the container is empty to allow the actual obar content to dictate the height when it's loaded.