### PR TITLE
HUB-803 - Part II

### DIFF
--- a/modules/uhsg_sisu/src/Services/SisuService.php
+++ b/modules/uhsg_sisu/src/Services/SisuService.php
@@ -96,8 +96,8 @@ class SisuService {
    * @param array $graphQlQuery
    *   Realisation ID.
    *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   Response object.
+   * @return array
+   *   Response array.
    */
   public function apiRequest(array $graphQlQuery) {
     // Request and return.
@@ -116,8 +116,8 @@ class SisuService {
    * @param array $option_overrides
    *   Optional options overrides.
    *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   Response object.
+   * @return array
+   *   Response array.
    */
   private function request($url, $method, $data = NULL, array $option_overrides = []) {
     $options = $option_overrides + $this->getRequestOptions($data);

--- a/modules/uhsg_user_sync/src/SamlAuth/UserSyncSubscriber.php
+++ b/modules/uhsg_user_sync/src/SamlAuth/UserSyncSubscriber.php
@@ -394,7 +394,9 @@ class UserSyncSubscriber implements EventSubscriberInterface {
     // Use Sisu Service
     // Map StudentDegreeProgram to a known degree programme and create flagging
     if($use_sisu_service){
-      if ($studyrights = $this->studyRightsService->getActiveStudyRights($student_number)) {
+      $studyrights = $this->studyRightsService->getActiveStudyRights($student_number);
+
+      if (!empty($studyrights)) {
         $technical_condition_field_name = $this->config->get('technical_condition_field_name');
         $primary_field_name = $this->config->get('primary_field_name');
         // Loop trough all studyrights


### PR DESCRIPTION
 It turns out that apparently the switch from Guzzle to Curl for Sisu queries was actually incomplete, and there were checks for an Response-object when the variable was in fact an array. Even though the variable in the data was as expected, this legacy check caused studyright fetches to basically always fail.

To fix this, I documented the return type in SisuService to an array, and it's also auto-converted to array in the places where its used in our custom code.

Other changes
-----------------------
* The problems were found by adding several new debug log entries for Sisu-queries, which can be enabled by adding to settings.local.php this:
  $settings['uhsg_sisu_log_responses'] = TRUE;
* This setting has been activated on QA and my own local env.
* Initialized a few vars to avoid notices.
* Also fixed a bunch of variable checks which caused notices etc, often by using !empty().
* studyright endDate is also accepted if its empty (is has to be empty or in the future), as that's how it's set in sisu test data.