### PR TITLE
HUB-800 - Add possibility to define degree_programme as 'all' 

### DIFF
--- a/modules/uhsg_active_degree_programme/src/ActiveDegreeProgrammeService.php
+++ b/modules/uhsg_active_degree_programme/src/ActiveDegreeProgrammeService.php
@@ -107,6 +107,25 @@ class ActiveDegreeProgrammeService {
   }
 
   /**
+   * Return true if we should not filter based on degree_program.
+   * @return bool
+   */
+  public function isAll() {
+    $return = FALSE;
+
+    // Fetch degree programme from query and headers
+    $degree_programme_from_query = $this->requestStack->getCurrentRequest()->get('degree_programme');
+    $degree_programme_from_headers = $this->requestStack->getCurrentRequest()->headers->get('x-degree-programme');
+
+    // If any of the degree_programme is set to 'all' well return 'TRUE'
+    if($degree_programme_from_query == "all" || $degree_programme_from_headers == "all") {
+      $return = TRUE;
+    }
+
+    return $return;
+  }
+
+  /**
    * Set active degree programme.
    * @param \Drupal\taxonomy\Entity\Term $term
    */

--- a/modules/uhsg_degree_programme_filtering/uhsg_degree_programme_filtering.module
+++ b/modules/uhsg_degree_programme_filtering/uhsg_degree_programme_filtering.module
@@ -48,24 +48,28 @@ function uhsg_degree_programme_filtering_preprocess_field(array &$variables, $ho
     uhsg_degree_programme_filtering_by_active_language($variables, $target_entity_type);
   }
 
-  // If we have active degree programme, filter by that or else filter out all
-  // targets that has any degree programme chosen.
-  $active_degree_programme_tid = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getId();
-  $active_degree_programme = NULL;
+  // Do not filter based on degree_program if it's set to 'all'
+  $filter = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->isAll();
+  if(!$filter) {
+    // If we have active degree programme, filter by that or else filter out all
+    // targets that has any degree programme chosen.
+    $active_degree_programme_tid = \Drupal::service('uhsg_active_degree_programme.active_degree_programme')->getId();
+    $active_degree_programme = NULL;
 
-  if ($active_degree_programme_tid) {
-    $active_degree_programme = Term::load($active_degree_programme_tid);
-    uhsg_degree_programme_filtering_by_degree_programme($variables, $active_degree_programme, $reference_field, $target_entity_type);
+    if ($active_degree_programme_tid) {
+      $active_degree_programme = Term::load($active_degree_programme_tid);
+      uhsg_degree_programme_filtering_by_degree_programme($variables, $active_degree_programme, $reference_field, $target_entity_type);
+    }
+    else {
+      uhsg_degree_programme_filtering_with_degree_programme($variables, $reference_field, $target_entity_type);
+    }
+
+    uhsg_degree_programme_filtering_by_paragraph_article_degree_programme($variables, $active_degree_programme, 'field_theme_section', 'field_theme_section_instructions', 'field_article_degree_programme');
+
+    // Because of these alterations, our result may vay depending on active
+    // degree programme.
+    $variables['#cache']['contexts'][] = 'active_degree_programme';
   }
-  else {
-    uhsg_degree_programme_filtering_with_degree_programme($variables, $reference_field, $target_entity_type);
-  }
-
-  uhsg_degree_programme_filtering_by_paragraph_article_degree_programme($variables, $active_degree_programme, 'field_theme_section', 'field_theme_section_instructions', 'field_article_degree_programme');
-
-  // Because of these alterations, our result may vay depending on active
-  // degree programme.
-  $variables['#cache']['contexts'][] = 'active_degree_programme';
 }
 
 /**
@@ -176,7 +180,6 @@ function uhsg_degree_programme_filtering_by_paragraph_article_degree_programme(a
                   }
                 }
               }
-
               if (!$valid_degree_programme_found) {
                 if (isset($variables['items'][$key]['content']['#paragraph']->{$article_reference_field_name}[$article_key])) {
                   $variables['items'][$key]['content']['#paragraph']->{$article_reference_field_name}[$article_key]->target_id = NULL;


### PR DESCRIPTION
* Add possibility to return all article contents without any degree_programme filtering by defining degree_programme either as a get-parameter or header info 'x-degree-programme'.

This will both allow siteimprove to see all content, and aswell content editors to see all content to see faster what content needs updating. 