### PR TITLE
HUB-776 - Handle special codes with sisu transfer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
+* HUB-776 - Handle special sisu codes with studyrights.
 
 ## 1.58
 Release date: 09.02.2021

--- a/modules/uhsg_sisu/src/Services/StudyRight/StudyRight.php
+++ b/modules/uhsg_sisu/src/Services/StudyRight/StudyRight.php
@@ -15,7 +15,7 @@ class StudyRight {
   /**
    * Save the code for studyright.
    */
-  public $code;  
+  public $code;
 
   /**
    * StudyRight constructor.
@@ -48,6 +48,33 @@ class StudyRight {
    * {@inheritdoc}
    */
   public function getCode() {
-    return $this->code;
+    // If "erikoislääkärit".
+    if(getSpecialDoctorCode($this->code)) {
+      return getSpecialDoctorCode($this->code);
+    }
+    // Else.
+    else {
+      return $this->code;
+    }
+  }
+
+  /**
+   * Handle special case for specialdoctors.
+   *
+   * @param $code
+   */
+  protected function getSpecialDoctorCode($code) {
+    $specialDoctorCodes = [
+      '320018', // Special Doctors 5 year education.
+      '320019', // Special Doctors 6 year education.
+      '320006', // Special dentistry education.
+      '220102' // Professional Licenciates.
+    ];
+
+    if(in_array(substr($code, 0, 6), $specialDoctorCodes)) {
+      return substr($code, 0, 6);
+    } else {
+      return NULL;
+    }
   }
 }

--- a/modules/uhsg_sisu/src/Services/StudyRight/StudyRight.php
+++ b/modules/uhsg_sisu/src/Services/StudyRight/StudyRight.php
@@ -49,8 +49,8 @@ class StudyRight {
    */
   public function getCode() {
     // If "erikoislääkärit".
-    if(getSpecialDoctorCode($this->code)) {
-      return getSpecialDoctorCode($this->code);
+    if(getSpecialCode($this->code)) {
+      return getSpecialCode($this->code);
     }
     // Else.
     else {
@@ -59,19 +59,19 @@ class StudyRight {
   }
 
   /**
-   * Handle special case for specialdoctors.
+   * Handle special case for Special Sisu Codes.
    *
    * @param $code
    */
-  protected function getSpecialDoctorCode($code) {
-    $specialDoctorCodes = [
+  protected function getSpecialCode($code) {
+    $specialCodes = [
       '320018', // Special Doctors 5 year education.
       '320019', // Special Doctors 6 year education.
       '320006', // Special dentistry education.
       '220102' // Professional Licenciates.
     ];
 
-    if(in_array(substr($code, 0, 6), $specialDoctorCodes)) {
+    if(in_array(substr($code, 0, 6), $specialCodes)) {
       return substr($code, 0, 6);
     } else {
       return NULL;


### PR DESCRIPTION
* We have special cases with studyrights where they have added more codes to sisu codes compared to oodi codes. This means we need to strip the end of the code and return the first part only. This is cause the instructions in Guide has been bundled together.

The code returned in Sisu is like: 220102-03230

We will need to combine the codes for these:

```
      '320018', // Special Doctors 5 year education.
      '320019', // Special Doctors 6 year education.
      '320006', // Special dentistry education.
      '220102' // Professional Licenciates.
```
