### PR TITLE
HUB-848: Deep links in tabbed containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
+* HUB-848 - Handle anchor links inside tab containers.
 
 
 

--- a/themes/uhsg_theme/js/tabs.js
+++ b/themes/uhsg_theme/js/tabs.js
@@ -1,0 +1,77 @@
+(function ($) {
+  'use strict';
+
+  Drupal.behaviors.uhsgTabs = {
+    attach: function (context, settings) {
+      // Check if we have a hash in the url. No need to continue, if not.
+      var hash = window.location.hash;
+      if (!hash) {
+        return;
+      }
+
+      // Find all tab containers. No need to continue, if none found.
+      var tabContainers = $('.js-tabs', context);
+      if (!tabContainers.length) {
+        return;
+      }
+
+      // Observer options.
+      var observerConfig = { attributes: true, childList: false, subtree: false };
+
+      // Mutation observer callback.
+      var observerCallback = function(mutationsList, observer) {
+        for (var i = 0, len = mutationsList.length; i < len; i++) {
+          var mutation = mutationsList[i];
+
+          if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+            if ($(mutation.target).hasClass('is-initialized')) {
+              activateTab(hash);
+              scrollToTab(hash);
+
+              // The deed is done. No need to continue this loop or even
+              // observe further.
+              observer.disconnect();
+              break;
+            }
+          }
+        }
+      };
+
+      // Create an observer instance linked to the callback function.
+      const observer = new MutationObserver(observerCallback);
+
+      // Start observing tab containers for configured mutations.
+      tabContainers.each(function() {
+        var tabContainer = $(this);
+
+        // No need to observe, if given hash id isn't inside this container.
+        if (tabContainer.find(hash).length === 0) {
+          return;
+        }
+
+        if (tabContainer.hasClass('is-initialized')) {
+          // Already initialized, no need to observe. Just activate the tab
+          // and scroll the window to it.
+          activateTab(hash);
+          scrollToTab(hash);
+        }
+        else {
+          // Start observing.
+          observer.observe(this, observerConfig);
+        }
+      });
+
+      // Activate given tab.
+      var activateTab = function(tabHash) {
+        var clickEvent = new Event('click');
+        $('a[href="' + hash + '"]').get(0).dispatchEvent(clickEvent);
+      };
+
+      // Scroll window to given tab.
+      var scrollToTab = function(tabHash) {
+        $(hash).get(0).scrollIntoView();
+      };
+    }
+  };
+
+}(jQuery));

--- a/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
+++ b/themes/uhsg_theme/templates/block/block--themes-per-user-group.html.twig
@@ -26,7 +26,7 @@
  */
 #}
 
-{{ attach_library('uhsg_theme/a11y_accordion_tabs') }}
+{{ attach_library('uhsg_theme/tabs') }}
 
 {%
   set classes = [

--- a/themes/uhsg_theme/uhsg_theme.libraries.yml
+++ b/themes/uhsg_theme/uhsg_theme.libraries.yml
@@ -67,6 +67,13 @@ menu_toggle:
     - core/jquery.once
     - core/matchMedia
 
+tabs:
+  version: 1.x
+  js:
+    js/tabs.js: {}
+  dependencies:
+    - uhsg_theme/a11y_accordion_tabs
+
 tooltip:
   version: 1.x
   js:


### PR DESCRIPTION
This PR restores a feature where deep links (aka. anchor links) that target an element inside a tabbed container will now properly activate the tab and then scroll the window to that anchor. This feature used to work before the accessibility updates to frontpage theme container where the whole tabbing mechanism had a major overhaul. Unfortunately the `a11y-accordion-tabs`-library didn't have a built-in support for this so we had to implement the following:

1. Register a mutation observer to find out when the tab container receives a `is-initialized` css class to indicate the tabbing script has done it's magic.
2. Activate the proper tab.
3. And finally scroll the window to given anchor element.