### PR TITLE
HUB-860: Translation import error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
+* HUB-860 - Fixing a Drupal core bug that was preventing translation file imports.
 * HUB-848 - Handle anchor links inside tab containers.
 * HUB-760 - Modifying font sizes and heading levels.
 

--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,8 @@
                 "2791693-38": "https://www.drupal.org/files/issues/2019-03-16/2791693-38.patch",
                 "3101344-20": "https://www.drupal.org/files/issues/2020-02-12/translations_not_save_invalid_path-3101344-20.patch",
                 "2972308-41 - content_translation performance": "https://www.drupal.org/files/issues/2019-12-03/allow-users-to-translate-editable-content-2972308-41.patch",
-                "3021671-7": "https://www.drupal.org/files/issues/2018-12-28/node_revisions_issue-3021671-07.patch"
+                "3021671-7": "https://www.drupal.org/files/issues/2018-12-28/node_revisions_issue-3021671-07.patch",
+                "2449895-80": "https://www.drupal.org/files/issues/2020-06-01/2449895-2-80.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfbe41095e342e1dc95672a0ac81f2fb",
+    "content-hash": "7544f93dde9574d3f8874e25184e2fa1",
     "packages": [
         {
             "name": "UH-StudentServices/uh_courses_embed",
@@ -2300,7 +2300,8 @@
                     "2791693-38": "https://www.drupal.org/files/issues/2019-03-16/2791693-38.patch",
                     "3101344-20": "https://www.drupal.org/files/issues/2020-02-12/translations_not_save_invalid_path-3101344-20.patch",
                     "2972308-41 - content_translation performance": "https://www.drupal.org/files/issues/2019-12-03/allow-users-to-translate-editable-content-2972308-41.patch",
-                    "3021671-7": "https://www.drupal.org/files/issues/2018-12-28/node_revisions_issue-3021671-07.patch"
+                    "3021671-7": "https://www.drupal.org/files/issues/2018-12-28/node_revisions_issue-3021671-07.patch",
+                    "2449895-80": "https://www.drupal.org/files/issues/2020-06-01/2449895-2-80.patch"
                 }
             },
             "autoload": {


### PR DESCRIPTION
This PR fixes a translation import error that surfaced when `json_api_imagestyles`-module was added. The root cause was in Drupal cause and luckily a patch was found (https://www.drupal.org/project/drupal/issues/2449895). This also fixes another marginally visible error where `/admin/content/files` view would error out if accessed within a temporary file lifetime after a translation file import.