### PR TITLE
HUB-846 - Adding and enabling uhsg_translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
+* HUB-846 - Enabling uhsg_translations for automatic translation imports, and a smoother release/deploy process.
 * HUB-860 - Fixing a Drupal core bug that was preventing translation file imports.
 * HUB-848 - Handle anchor links inside tab containers.
 * HUB-760 - Modifying font sizes and heading levels.

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -111,6 +111,7 @@ module:
   uhsg_sitemap: 0
   uhsg_some_links: 0
   uhsg_themes: 0
+  uhsg_translations: 0  
   uhsg_user_sync: 0
   user: 0
   video_embed_field: 0

--- a/modules/uhsg_translations/README.txt
+++ b/modules/uhsg_translations/README.txt
@@ -1,0 +1,26 @@
+UHSG Translations (fork of UHC Translations)
+
+When adding new translations:
+
+1. Add a new helper function to uhsg_translations.install with a
+$translation_helper->addTranslation()-call for all added translations.
+
+2. Create a new uhsg_translations_update_N hook implementation with a call to above
+created helper function.
+
+3. Also call the above added helper function in uhsg_translations_install to
+make sure all translations would be applied even if this module was enabled on a
+fresh db.
+
+Overriding existing translations
+By default existing translations are not overridden but it is possible by adding a
+fourth argument TRUE in the $translation_helper->addTranslation()-call.
+@see: Drupal\uhsg_translations\Helpers\TranslationHelper::addTranslation()
+
+
+NOTE: Thanks to this module we can automatize translation imports and ignore
+instructions in the old RELEASE.md file, such as:
+"10. Jos `translations`-hakemiston `*.po`-tiedostot ovat muuttuneet uudessa
+ asennuksessa, kirjaudu Drupaliin ja tuo uudet käännökset sisään
+   `/admin/config/regional/translate/import`-polusta ("Overwrite non-customized
+    translations" sekä "Overwrite existing customized translations" **päällä**).""

--- a/modules/uhsg_translations/src/Helpers/TranslationHelper.php
+++ b/modules/uhsg_translations/src/Helpers/TranslationHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\uhsg_translations\Helpers;
+
+use Drupal\locale\SourceString;
+use Drupal\locale\StringDatabaseStorage;
+
+/**
+ * User interface translation helper methods.
+ *
+ * @package Drupal\uhsg_translations\Helpers
+ */
+class TranslationHelper {
+
+  /**
+   * Locale storage.
+   *
+   * @var \Drupal\locale\StringDatabaseStorage
+   */
+  private $localeStorage;
+
+  /**
+   * Constructor.
+   *
+   * @param Drupal\locale\StringDatabaseStorage $localeStorage
+   *   Locale storage.
+   */
+  public function __construct(StringDatabaseStorage $localeStorage) {
+    $this->localeStorage = $localeStorage;
+  }
+
+  /**
+   * Add a single translation string.
+   *
+   * @param string $source_string
+   *   Source string.
+   * @param string $langcode
+   *   The langcode.
+   * @param string $translated_string
+   *   Translated string.
+   * @param bool $override_existing
+   *   Override existing translation. Defaults to FALSE.
+   */
+  public function addTranslation($source_string, $langcode, $translated_string, $override_existing = FALSE) {
+    // First check if the source string exists already.
+    $string = $this->localeStorage->findString([
+      'source' => $source_string,
+    ]);
+
+    if (is_null($string)) {
+      // Create a new source, if none existed.
+      $string = new SourceString();
+      $string->setString($source_string);
+      $string->setStorage($this->localeStorage);
+      $string->save();
+    }
+    elseif (!$override_existing) {
+      // Search again to make sure we don't have an existing translation.
+      $string = $this->localeStorage->findString([
+        'source' => $source_string,
+        'language' => $langcode,
+        'translated' => FALSE,
+      ]);
+    }
+
+    if ($string) {
+      // Create translation.
+      $translation = $this->localeStorage->createTranslation([
+        'lid' => $string->lid,
+        'language' => $langcode,
+        'translation' => $translated_string,
+      ]);
+      $translation->save();
+    }
+  }
+
+}

--- a/modules/uhsg_translations/uhsg_translations.info.yml
+++ b/modules/uhsg_translations/uhsg_translations.info.yml
@@ -1,0 +1,7 @@
+name: UHSG Translations
+type: module
+description: "Install and update hooks to update interface translations through code."
+core_version_requirement: ^8.8 || ^9
+package: UHSG
+dependencies:
+  - locale

--- a/modules/uhsg_translations/uhsg_translations.install
+++ b/modules/uhsg_translations/uhsg_translations.install
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Contains uhsg_translations.install.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function uhsg_translations_install() {
+  _uhsg_translations_8000();
+//  _uhsg_translations_8001(); <-- add new translations like this!
+}
+
+/**
+ * Adding interface translations.
+ */
+function uhsg_translations_update_8000() {
+  _uhsg_translations_8000();
+}
+
+
+/**
+ * Helper function 8000.
+ */
+function _uhsg_translations_8000() {
+  $translation_helper = \Drupal::service('uhsg_translations.translation_helper');
+
+  // Finnish and swedish translations (this can be considered an example)
+  $translation_helper->addTranslation('News', 'fi', 'Uutinen');
+  $translation_helper->addTranslation('News', 'sv', 'Nyhet');
+}
+
+/**
+ * Helper function 8001.
+ * Add new translations with 2 new functions:
+ * - uhsg_translations_8xxx()
+ * - _uhsg_translations_8xxx()
+ */
+ /*
+function _uhsg_translations_8001() {
+  $translation_helper = \Drupal::service('uhsg_translations.translation_helper');
+
+  // Ajax throbber.
+  $translation_helper->addTranslation('Please wait...', 'fi', 'Odota...');
+}
+*/

--- a/modules/uhsg_translations/uhsg_translations.services.yml
+++ b/modules/uhsg_translations/uhsg_translations.services.yml
@@ -1,0 +1,4 @@
+services:
+  uhsg_translations.translation_helper:
+    class: Drupal\uhsg_translations\Helpers\TranslationHelper
+    arguments: ["@locale.storage"]


### PR DESCRIPTION
Adding and enabling uhsg_translations, which is mostly a copy/fork of uhc_translations (courses).

The readme.txt has been updated with a section about deployment/releases, as the translation import used to be part of the manual steps.

NOTE: comparable PR for new Silta repo is at:
https://github.com/wunderio/client-fi-uh-guide/pull/76