### PR TITLE
HUB-720: Instruction page UI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
-
+* HUB-720 - Updating Instruction content layout and visuals to better match Studies service guidelines.
 
 ## 1.60
 Release date: 23.03.2021

--- a/modules/uhsg_themes/src/Plugin/Block/ThemesReferencingInstructions.php
+++ b/modules/uhsg_themes/src/Plugin/Block/ThemesReferencingInstructions.php
@@ -168,7 +168,7 @@ class ThemesReferencingInstructions extends BlockBase implements ContainerFactor
         '#theme' => 'item_list',
         '#type' => 'ul',
         '#items' => $links,
-        '#title' => t('Themes'),
+        '#title' => t('The instruction belongs to the following themes'),
       ];
     }
 

--- a/modules/uhsg_translations/uhsg_translations.install
+++ b/modules/uhsg_translations/uhsg_translations.install
@@ -9,40 +9,23 @@
  * Implements hook_install().
  */
 function uhsg_translations_install() {
-  _uhsg_translations_8000();
-//  _uhsg_translations_8001(); <-- add new translations like this!
+  _uhsg_translations_8001();
 }
 
 /**
  * Adding interface translations.
  */
-function uhsg_translations_update_8000() {
-  _uhsg_translations_8000();
-}
-
-
-/**
- * Helper function 8000.
- */
-function _uhsg_translations_8000() {
-  $translation_helper = \Drupal::service('uhsg_translations.translation_helper');
-
-  // Finnish and swedish translations (this can be considered an example)
-  $translation_helper->addTranslation('News', 'fi', 'Uutinen');
-  $translation_helper->addTranslation('News', 'sv', 'Nyhet');
+function uhsg_translations_update_8001() {
+  _uhsg_translations_8001();
 }
 
 /**
  * Helper function 8001.
- * Add new translations with 2 new functions:
- * - uhsg_translations_8xxx()
- * - _uhsg_translations_8xxx()
  */
- /*
 function _uhsg_translations_8001() {
   $translation_helper = \Drupal::service('uhsg_translations.translation_helper');
 
-  // Ajax throbber.
-  $translation_helper->addTranslation('Please wait...', 'fi', 'Odota...');
+  // Theme link heading.
+  $translation_helper->addTranslation('The instruction belongs to the following themes', 'fi', 'Ohje kuuluu seuraaviin teemoihin');
+  $translation_helper->addTranslation('The instruction belongs to the following themes', 'sv', 'Instruktionen hör till följande teman');
 }
-*/

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8873,6 +8873,18 @@ li.avatar.avatar--default img {
   padding-top: 1.5em;
 }
 
+@media (min-width: 48em) {
+  .page-node-type-article #block-breadcrumbs {
+    margin-left: calc(33.33333% + 4em);
+  }
+}
+
+@media (min-width: 60em) {
+  .page-node-type-article #block-breadcrumbs {
+    margin-left: calc(25% + 4em);
+  }
+}
+
 .breadcrumbs {
   font-size: 0.875rem;
 }

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8529,6 +8529,104 @@ input[type="text"].search-form-large__input {
 }
 
 /* STUDENT GUIDE THEMING */
+/*
+ section: 3.7
+ title: Buttons
+ description:
+*/
+/*
+ section: 3.7.1
+ title: Button
+ template: 3_7_1-button
+ description:
+*/
+input[type="submit"], .button--small, .accordion__title,
+.button--accordion,
+.button--action-before,
+.button--action, .button--anchor, .button--expand, .button--icon, .button--outline, .accordion--dark .accordion__title, .cc_btn,
+.button {
+  background-color: #0479A4;
+}
+
+input.theme-transparent[type="submit"], .theme-transparent.button--small, .theme-transparent.accordion__title,
+.theme-transparent.button--accordion,
+.theme-transparent.button--action-before,
+.theme-transparent.button--action, .theme-transparent.button--anchor, .theme-transparent.button--expand, .theme-transparent.button--icon, .theme-transparent.button--outline, .theme-transparent.cc_btn, input.theme-transparent-alt[type="submit"], .theme-transparent-alt.button--small, .theme-transparent-alt.accordion__title,
+.theme-transparent-alt.button--accordion,
+.theme-transparent-alt.button--action-before,
+.theme-transparent-alt.button--action, .theme-transparent-alt.button--anchor, .theme-transparent-alt.button--expand, .theme-transparent-alt.button--icon, .theme-transparent-alt.button--outline, .theme-transparent-alt.cc_btn,
+.button.theme-transparent,
+.button.theme-transparent-alt {
+  color: #0479A4;
+}
+
+input.theme-transparent:hover[type="submit"], .theme-transparent.button--small:hover, .theme-transparent.accordion__title:hover,
+.theme-transparent.button--accordion:hover,
+.theme-transparent.button--action-before:hover,
+.theme-transparent.button--action:hover, .theme-transparent.button--anchor:hover, .theme-transparent.button--expand:hover, .theme-transparent.button--icon:hover, .theme-transparent.button--outline:hover, .theme-transparent.cc_btn:hover, input.theme-transparent-alt:hover[type="submit"], .theme-transparent-alt.button--small:hover, .theme-transparent-alt.accordion__title:hover,
+.theme-transparent-alt.button--accordion:hover,
+.theme-transparent-alt.button--action-before:hover,
+.theme-transparent-alt.button--action:hover, .theme-transparent-alt.button--anchor:hover, .theme-transparent-alt.button--expand:hover, .theme-transparent-alt.button--icon:hover, .theme-transparent-alt.button--outline:hover, .theme-transparent-alt.cc_btn:hover,
+.button.theme-transparent:hover,
+.button.theme-transparent-alt:hover {
+  background-color: #0479A4;
+}
+
+/*
+ section: 3.7.3
+ title: Button action
+  template: 3_7_3-button--action
+ description:
+*/
+
+.button--action-before:after,
+.button--action:after {
+  background-color: #0479A4;
+}
+
+
+.button--action-before:focus:after,
+.button--action-before:hover:after,
+.button--action:focus:after,
+.button--action:hover:after {
+  background: #005379;
+}
+
+
+.button--action-before:active:after,
+.button--action:active:after {
+  background: #003146;
+}
+
+
+.theme-transparent.button--action-before:after,
+.theme-transparent-alt.button--action-before:after,
+.button--action.theme-transparent:after,
+.button--action.theme-transparent-alt:after {
+  color: #0479A4;
+}
+
+/*
+ section: 3.7.8
+ title: Button group (small buttons)
+ template: 3_7_8-button-group--small
+ description:
+*/
+/*
+ section: 3.7.9
+ title: Button outline
+ template: 3_7_9-button-outline
+ description:
+*/
+.button--outline {
+  border-color: #0479A4;
+  color: #0479A4;
+}
+
+.button--outline:hover {
+  background-color: #0479A4;
+}
+
 .container {
   margin: 0 auto;
   max-width: 80em;
@@ -8901,7 +8999,7 @@ li.avatar.avatar--default img {
 
 .breadcrumbs__item a {
   text-transform: none;
-  color: #0479a5;
+  color: #0479A4;
   font-weight: 500;
   letter-spacing: 0;
 }
@@ -8915,7 +9013,7 @@ li.avatar.avatar--default img {
   background-position: center;
   background-repeat: no-repeat;
   background-size: contain;
-  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000" fill="%230479A5" stroke="%230479A5" stroke-width="1"%3E%3Cpath d="M345.3,998.7c-30.3,0-55.4-25.2-55.4-55.6c0-30.4,25.1-55.6,55.4-55.6h479.9l0-509.9L500,114.2L174.8,377.6%0Av565.5c0,30.4-25.1,55.6-55.4,55.6c-30.3,0-55.4-25.2-55.4-55.6l0-567.6c0-31.5,14.6-61.9,38.7-81.9L434.1,25%0Ac37.7-30.4,93-30.4,130.7,0l332.5,268.6c25.1,19.9,38.7,49.3,38.7,81.9v568.7c0,29.4-25.1,54.6-55.4,54.6L345.3,998.7z" /%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000" fill="%230479A4" stroke="%230479A4" stroke-width="1"%3E%3Cpath d="M345.3,998.7c-30.3,0-55.4-25.2-55.4-55.6c0-30.4,25.1-55.6,55.4-55.6h479.9l0-509.9L500,114.2L174.8,377.6%0Av565.5c0,30.4-25.1,55.6-55.4,55.6c-30.3,0-55.4-25.2-55.4-55.6l0-567.6c0-31.5,14.6-61.9,38.7-81.9L434.1,25%0Ac37.7-30.4,93-30.4,130.7,0l332.5,268.6c25.1,19.9,38.7,49.3,38.7,81.9v568.7c0,29.4-25.1,54.6-55.4,54.6L345.3,998.7z" /%3E%3C/svg%3E');
 }
 
 .breadcrumbs--home-icon-first .breadcrumbs__item:first-child a span {
@@ -10368,29 +10466,29 @@ ul.pager > li a:focus {
 }
 
 .horizontal-tabs .horizontal-tab-button {
-  border-top-color: #0479a5;
+  border-top-color: #0479A4;
 }
 
 .horizontal-tabs .horizontal-tab-button > a {
-  background: #0479a5;
+  background: #0479A4;
 }
 
 .horizontal-tabs .horizontal-tab-button.selected {
-  border-top-color: #0479a5;
+  border-top-color: #0479A4;
 }
 
 .horizontal-tabs .horizontal-tab-button.selected a {
-  -webkit-box-shadow: inset 0 3px 0 #0479a5;
-          box-shadow: inset 0 3px 0 #0479a5;
-  color: #0479a5;
+  -webkit-box-shadow: inset 0 3px 0 #0479A4;
+          box-shadow: inset 0 3px 0 #0479A4;
+  color: #0479A4;
 }
 
 .horizontal-tabs .horizontal-tab-button.selected:hover {
-  color: #0479a5;
+  color: #0479A4;
 }
 
 .horizontal-tabs .horizontal-tab-button.selected:hover > a {
-  color: #0479a5;
+  color: #0479A4;
 }
 
 .horizontal-tabs .horizontal-tab-button > .tabs-trigger {
@@ -10405,13 +10503,13 @@ ul.pager > li a:focus {
 }
 
 .horizontal-tabs .horizontal-tab-button > .tabs-trigger.is-selected {
-  border-top-color: #0479a5;
+  border-top-color: #0479A4;
   border-bottom-color: transparent;
   z-index: 2;
   background-color: #FFF;
-  -webkit-box-shadow: inset 0 3px 0 #0479a5;
-          box-shadow: inset 0 3px 0 #0479a5;
-  color: #0479a5;
+  -webkit-box-shadow: inset 0 3px 0 #0479A4;
+          box-shadow: inset 0 3px 0 #0479A4;
+  color: #0479A4;
 }
 
 .horizontal-tabs .tabs-panel.is-hidden {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8529,6 +8529,12 @@ input[type="text"].search-form-large__input {
 }
 
 /* STUDENT GUIDE THEMING */
+/**
+ * New grid width calculations are derived from these premises:
+ * - FULL = 12*GRID + 11*GUTTER
+ * - SIDE_COL = 4*GRID + 3*GUTTER
+ * - MAIN_COL = (8*GRID + 7*GUTTER) - 16px
+ */
 /*
  section: 3.7
  title: Buttons
@@ -8786,41 +8792,26 @@ input.theme-transparent:hover[type="submit"], .theme-transparent.button--small:h
     display: flex;
   }
   .col-right {
-    -ms-flex-preferred-size: 33.33333%;
-        flex-basis: 33.33333%;
+    -ms-flex-preferred-size: calc((100%/3) - 64px/3);
+        flex-basis: calc((100%/3) - 64px/3);
     -ms-flex-negative: 0;
         flex-shrink: 0;
-    margin-left: 4em;
+    margin-left: 48px;
   }
   .col-left {
-    -ms-flex-preferred-size: 33.33333%;
-        flex-basis: 33.33333%;
+    -ms-flex-preferred-size: calc((100%/3) - 64px/3);
+        flex-basis: calc((100%/3) - 64px/3);
     -ms-flex-negative: 0;
         flex-shrink: 0;
-    margin-right: 4em;
+    margin-right: 48px;
   }
   .col-main {
-    -ms-flex-preferred-size: 66.66667%;
-        flex-basis: 66.66667%;
+    -ms-flex-preferred-size: calc((100%*2/3) - 32px/3 - 16px);
+        flex-basis: calc((100%*2/3) - 32px/3 - 16px);
     -webkit-box-flex: 1;
         -ms-flex-positive: 1;
             flex-grow: 1;
     min-width: 0;
-  }
-}
-
-@media (min-width: 60em) {
-  .col-right {
-    -ms-flex-preferred-size: 25%;
-        flex-basis: 25%;
-  }
-  .col-left {
-    -ms-flex-preferred-size: 25%;
-        flex-basis: 25%;
-  }
-  .col-main {
-    -ms-flex-preferred-size: 50%;
-        flex-basis: 50%;
   }
 }
 
@@ -8985,13 +8976,7 @@ li.avatar.avatar--default img {
 
 @media (min-width: 48em) {
   .page-node-type-article #block-breadcrumbs {
-    margin-left: calc(33.33333% + 4em);
-  }
-}
-
-@media (min-width: 60em) {
-  .page-node-type-article #block-breadcrumbs {
-    margin-left: calc(25% + 4em);
+    margin-left: calc((100%/3) - 64px/3 + 48px);
   }
 }
 
@@ -10598,6 +10583,14 @@ ul.pager > li a:focus {
   display: inline-block;
   position: static;
   margin-left: 1em;
+}
+
+.box-story__meta-item .tag-list__item {
+  color: inherit;
+}
+
+.box-story__meta-item .tag-list__item a {
+  color: inherit;
 }
 
 /*

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8606,6 +8606,18 @@ input.theme-transparent:hover[type="submit"], .theme-transparent.button--small:h
   color: #0479A4;
 }
 
+
+.theme-transparent.button--action-before:hover,
+.theme-transparent.button--action-before:hover:after,
+.theme-transparent-alt.button--action-before:hover,
+.theme-transparent-alt.button--action-before:hover:after,
+.button--action.theme-transparent:hover,
+.button--action.theme-transparent:hover:after,
+.button--action.theme-transparent-alt:hover,
+.button--action.theme-transparent-alt:hover:after {
+  background-color: transparent;
+}
+
 /*
  section: 3.7.8
  title: Button group (small buttons)
@@ -10571,10 +10583,15 @@ ul.pager > li a:focus {
 }
 
 .tag-list__item {
+  color: #555555;
   display: inline;
   padding-right: 0;
   margin-right: 1em;
   vertical-align: initial;
+}
+
+.tag-list__item a {
+  color: #555555;
 }
 
 .tag-list__item:after {

--- a/themes/uhsg_theme/css/style.css
+++ b/themes/uhsg_theme/css/style.css
@@ -8678,20 +8678,39 @@ input[type="text"].search-form-large__input {
   .col-right {
     -ms-flex-preferred-size: 33.33333%;
         flex-basis: 33.33333%;
+    -ms-flex-negative: 0;
+        flex-shrink: 0;
     margin-left: 4em;
   }
   .col-left {
     -ms-flex-preferred-size: 33.33333%;
         flex-basis: 33.33333%;
+    -ms-flex-negative: 0;
+        flex-shrink: 0;
     margin-right: 4em;
   }
   .col-main {
     -ms-flex-preferred-size: 66.66667%;
         flex-basis: 66.66667%;
-    -webkit-box-flex: 2;
-        -ms-flex-positive: 2;
-            flex-grow: 2;
+    -webkit-box-flex: 1;
+        -ms-flex-positive: 1;
+            flex-grow: 1;
     min-width: 0;
+  }
+}
+
+@media (min-width: 60em) {
+  .col-right {
+    -ms-flex-preferred-size: 25%;
+        flex-basis: 25%;
+  }
+  .col-left {
+    -ms-flex-preferred-size: 25%;
+        flex-basis: 25%;
+  }
+  .col-main {
+    -ms-flex-preferred-size: 50%;
+        flex-basis: 50%;
   }
 }
 
@@ -9514,6 +9533,28 @@ input[type="submit"].button--reset + i {
 
 #obar-footer {
   background: #000;
+}
+
+/*
+ section: 9.1.1
+ title: Index
+ template: 9_1_1-index
+ description: Index of content
+*/
+@media (min-width: 48em) {
+  .index {
+    -webkit-columns: 1;
+       -moz-columns: 1;
+            columns: 1;
+  }
+}
+
+@media (min-width: 60em) {
+  .index {
+    -webkit-columns: 2;
+       -moz-columns: 2;
+            columns: 2;
+  }
 }
 
 @media (min-width: 48em) {

--- a/themes/uhsg_theme/sass/components/_breadcrumbs.scss
+++ b/themes/uhsg_theme/sass/components/_breadcrumbs.scss
@@ -1,5 +1,15 @@
 #block-breadcrumbs {
   padding-top: 1.5em;
+
+  .page-node-type-article & {
+    @include breakpoint($small) {
+      margin-left: calc(#{$side-column-width-medium} + #{$column-gutter});
+    }
+    
+    @include breakpoint($medium) {
+      margin-left: calc(#{$side-column-width} + #{$column-gutter});
+    }
+  }
 }
 
 .breadcrumbs {

--- a/themes/uhsg_theme/sass/components/_breadcrumbs.scss
+++ b/themes/uhsg_theme/sass/components/_breadcrumbs.scss
@@ -3,11 +3,7 @@
 
   .page-node-type-article & {
     @include breakpoint($small) {
-      margin-left: calc(#{$side-column-width-medium} + #{$column-gutter});
-    }
-    
-    @include breakpoint($medium) {
-      margin-left: calc(#{$side-column-width} + #{$column-gutter});
+      margin-left: $breadcrumbs-align-to-main-margin;
     }
   }
 }

--- a/themes/uhsg_theme/sass/components/_index.scss
+++ b/themes/uhsg_theme/sass/components/_index.scss
@@ -1,0 +1,15 @@
+/*
+ section: 9.1.1
+ title: Index
+ template: 9_1_1-index
+ description: Index of content
+*/
+.index {
+  @include breakpoint($small) {
+    columns: 1;
+  }
+
+  @include breakpoint($medium) {
+    columns: 2;
+  }
+}

--- a/themes/uhsg_theme/sass/components/_tag-list.scss
+++ b/themes/uhsg_theme/sass/components/_tag-list.scss
@@ -4,10 +4,16 @@
 }
 
 .tag-list__item {
+  color: $lightgray;
   display: inline;
   padding-right: 0;
   margin-right: 1em;
   vertical-align: initial;
+
+  a {
+    color: $lightgray;
+  }
+
   &:after {
     display: inline-block;
     position: static;

--- a/themes/uhsg_theme/sass/components/_tag-list.scss
+++ b/themes/uhsg_theme/sass/components/_tag-list.scss
@@ -19,4 +19,12 @@
     position: static;
     margin-left: 1em;
   }
+
+  .box-story__meta-item & {
+    color: inherit;
+
+    a {
+      color: inherit;
+    }
+  }
 }

--- a/themes/uhsg_theme/sass/layout/_layout.scss
+++ b/themes/uhsg_theme/sass/layout/_layout.scss
@@ -92,16 +92,31 @@
   }
   .col-right {
     flex-basis: (100% / 3);
+    flex-shrink: 0;
     margin-left: 4em;
   }
 
   .col-left {
     flex-basis: (100% / 3);
+    flex-shrink: 0;
     margin-right: 4em;
   }
   .col-main {
     flex-basis: (100% / 3) * 2;
-    flex-grow: 2;
+    flex-grow: 1;
     min-width: 0;
+  }
+}
+
+@include breakpoint($medium) {
+  .col-right {
+    flex-basis: (100% / 4);
+  }
+
+  .col-left {
+    flex-basis: (100% / 4);
+  }
+  .col-main {
+    flex-basis: (100% / 2);
   }
 }

--- a/themes/uhsg_theme/sass/layout/_layout.scss
+++ b/themes/uhsg_theme/sass/layout/_layout.scss
@@ -91,32 +91,19 @@
     display: flex;
   }
   .col-right {
-    flex-basis: $side-column-width-medium;
+    flex-basis: $side-column-width;
     flex-shrink: 0;
     margin-left: $column-gutter;
   }
 
   .col-left {
-    flex-basis: $side-column-width-medium;
+    flex-basis: $side-column-width;
     flex-shrink: 0;
     margin-right: $column-gutter;
   }
   .col-main {
-    flex-basis: $main-column-width-medium;
+    flex-basis: $main-column-width;
     flex-grow: 1;
     min-width: 0;
-  }
-}
-
-@include breakpoint($medium) {
-  .col-right {
-    flex-basis: $side-column-width;
-  }
-
-  .col-left {
-    flex-basis: $side-column-width;
-  }
-  .col-main {
-    flex-basis: $main-column-width;
   }
 }

--- a/themes/uhsg_theme/sass/layout/_layout.scss
+++ b/themes/uhsg_theme/sass/layout/_layout.scss
@@ -91,18 +91,18 @@
     display: flex;
   }
   .col-right {
-    flex-basis: (100% / 3);
+    flex-basis: $side-column-width-medium;
     flex-shrink: 0;
-    margin-left: 4em;
+    margin-left: $column-gutter;
   }
 
   .col-left {
-    flex-basis: (100% / 3);
+    flex-basis: $side-column-width-medium;
     flex-shrink: 0;
-    margin-right: 4em;
+    margin-right: $column-gutter;
   }
   .col-main {
-    flex-basis: (100% / 3) * 2;
+    flex-basis: $main-column-width-medium;
     flex-grow: 1;
     min-width: 0;
   }
@@ -110,13 +110,13 @@
 
 @include breakpoint($medium) {
   .col-right {
-    flex-basis: (100% / 4);
+    flex-basis: $side-column-width;
   }
 
   .col-left {
-    flex-basis: (100% / 4);
+    flex-basis: $side-column-width;
   }
   .col-main {
-    flex-basis: (100% / 2);
+    flex-basis: $main-column-width;
   }
 }

--- a/themes/uhsg_theme/sass/objects/_button.scss
+++ b/themes/uhsg_theme/sass/objects/_button.scss
@@ -51,6 +51,11 @@
     &:after {
       color: $blue-a11y;
     }
+
+    &:hover,
+    &:hover:after {
+      background-color: transparent;
+    }
   }
 }
 

--- a/themes/uhsg_theme/sass/objects/_button.scss
+++ b/themes/uhsg_theme/sass/objects/_button.scss
@@ -1,0 +1,77 @@
+/*
+ section: 3.7
+ title: Buttons
+ description:
+*/
+
+/*
+ section: 3.7.1
+ title: Button
+ template: 3_7_1-button
+ description:
+*/
+%button,
+.button {
+  background-color: $blue-a11y;
+
+  &.theme-transparent,
+  &.theme-transparent-alt {
+    color: $blue-a11y;
+
+    &:hover {
+      background-color: $blue-a11y;
+    }
+  }
+}
+
+/*
+ section: 3.7.3
+ title: Button action
+  template: 3_7_3-button--action
+ description:
+*/
+%button--action,
+.button--action {
+  // Icon + background
+  &:after {
+    background-color: $blue-a11y;
+  }
+
+  &:focus:after,
+  &:hover:after {
+    background: $darkblue;
+  }
+
+  &:active:after {
+    background: $darkblue--active;
+  }
+
+  &.theme-transparent,
+  &.theme-transparent-alt {
+    &:after {
+      color: $blue-a11y;
+    }
+  }
+}
+
+/*
+ section: 3.7.8
+ title: Button group (small buttons)
+ template: 3_7_8-button-group--small
+ description:
+*/
+
+/*
+ section: 3.7.9
+ title: Button outline
+ template: 3_7_9-button-outline
+ description:
+*/
+.button--outline {
+  border-color: $blue-a11y;
+  color: $blue-a11y;
+
+  &:hover {
+    background-color: $blue-a11y;
+  }
+}

--- a/themes/uhsg_theme/sass/style.scss
+++ b/themes/uhsg_theme/sass/style.scss
@@ -41,6 +41,7 @@
 @import "variables/**/*";
 @import "functions/**/*";
 @import "mixins/**/*";
+@import "objects/**/*";
 @import "layout/**/*";
 @import "components/**/*";
 @import "common-elements/**/*";

--- a/themes/uhsg_theme/sass/variables/_variables.scss
+++ b/themes/uhsg_theme/sass/variables/_variables.scss
@@ -1,11 +1,18 @@
+// Layout.
 $grid-gutter: 1em;
-
 $page-gutter: 2em;
 $page-gutter-mobile: 1em;
+$side-column-width: 100% / 4;
+$side-column-width-medium: 100% / 3;
+$main-column-width: $side-column-width * 2;
+$main-column-width-medium: $side-column-width-medium * 2;
+$column-gutter: 4em;
 
+// Breakpoints.
 $bp-xsmall: 30em;
 $xsmall: $bp-xsmall;
 
+// Colors.
 $green: #4FB151;
 $purple: #7b46a3;
 $blue-a11y: #0479a5;

--- a/themes/uhsg_theme/sass/variables/_variables.scss
+++ b/themes/uhsg_theme/sass/variables/_variables.scss
@@ -2,11 +2,19 @@
 $grid-gutter: 1em;
 $page-gutter: 2em;
 $page-gutter-mobile: 1em;
-$side-column-width: 100% / 4;
-$side-column-width-medium: 100% / 3;
-$main-column-width: $side-column-width * 2;
-$main-column-width-medium: $side-column-width-medium * 2;
-$column-gutter: 4em;
+
+/**
+ * New grid width calculations are derived from these premises:
+ * - FULL = 12*GRID + 11*GUTTER
+ * - SIDE_COL = 4*GRID + 3*GUTTER
+ * - MAIN_COL = (8*GRID + 7*GUTTER) - 16px
+ */
+$new-grid-gutter: 32px;
+$column-extra-gutter: 16px;
+$column-gutter: $new-grid-gutter + $column-extra-gutter;
+$side-column-width: calc((100%/3) - #{2 * $new-grid-gutter}/3);
+$main-column-width: calc((100%*2/3) - #{$new-grid-gutter}/3 - #{$column-extra-gutter});
+$breadcrumbs-align-to-main-margin: calc((100%/3) - #{2 * $new-grid-gutter}/3 + #{$column-gutter});
 
 // Breakpoints.
 $bp-xsmall: 30em;

--- a/themes/uhsg_theme/sass/variables/_variables.scss
+++ b/themes/uhsg_theme/sass/variables/_variables.scss
@@ -15,7 +15,7 @@ $xsmall: $bp-xsmall;
 // Colors.
 $green: #4FB151;
 $purple: #7b46a3;
-$blue-a11y: #0479a5;
+$blue-a11y: #0479A4;
 $color-link: #0e688b;
 $color-link-hover: #005379;
 $avatarbg: rgba($purple, .45);

--- a/themes/uhsg_theme/templates/fields/field--field-article-paragraph.html.twig
+++ b/themes/uhsg_theme/templates/fields/field--field-article-paragraph.html.twig
@@ -3,15 +3,18 @@
 {% block header %}
   {% if table_of_contents %}
     {{ attach_library('uhsg_theme/anchor') }}
-    <h2 class="visually-hidden">{{ 'On this page'|t }}</h2>
-    <div class="index container">
-      {% for item in table_of_contents %}
-        <div class="index__row">
-          <a href="{{ '#paragraph-' ~ item.id }}" class="index__link button--action-before icon--arrow-down theme-transparent">
-            {{- item.title.value -}}
-          </a>
-        </div>
-      {% endfor %}
+    <div class="container col-container">
+      <div class="col-left"></div>
+      <div class="index col-main">
+        <h2 class="visually-hidden">{{ 'On this page'|t }}</h2>
+        {% for item in table_of_contents %}
+          <div class="index__row">
+            <a href="{{ '#paragraph-' ~ item.id }}" class="index__link button--action-before icon--arrow-down theme-transparent">
+              {{- item.title.value -}}
+            </a>
+          </div>
+        {% endfor %}
+      </div>
     </div>
   {% endif %}
 {% endblock %}

--- a/themes/uhsg_theme/templates/node/node--article--full.html.twig
+++ b/themes/uhsg_theme/templates/node/node--article--full.html.twig
@@ -98,18 +98,16 @@
 
 <article {{ attributes.addClass(node_classes) }}>
   <div{{ content_attributes.addClass(container_classes) }}>
+    <div class="col-left">
+      {{ link_to_instructions_for_students }}
+      {{ themes }}
+    </div>
     <div class="col-main">
       <h1> {{ label }} </h1>
       {{ degree_programme_switcher }}
       {{ other_education_provider_switcher }}
       {{ content|without('field_article_paragraph', 'field_article_related') }}
     </div>
-    {% if (link_to_instructions_for_students or themes) %}
-      <div class="col-right">
-        {{ link_to_instructions_for_students }}
-        {{ themes }}
-      </div>
-    {% endif %}
   </div>
   {{ content.field_article_paragraph }}
   {% if content.field_article_related %}

--- a/themes/uhsg_theme/templates/node/node--article--full.html.twig
+++ b/themes/uhsg_theme/templates/node/node--article--full.html.twig
@@ -81,8 +81,7 @@
   set container_classes = [
     'container',
     'tube',
-    'article__content',
-    'col-container'
+    'article__content'
   ]
 %}
 
@@ -98,15 +97,22 @@
 
 <article {{ attributes.addClass(node_classes) }}>
   <div{{ content_attributes.addClass(container_classes) }}>
-    <div class="col-left">
-      {{ link_to_instructions_for_students }}
-      {{ themes }}
+    <div class="col-container">
+      <div class="col-left"></div>
+      <div class="col-main">
+        <h1> {{ label }} </h1>
+      </div>
     </div>
-    <div class="col-main">
-      <h1> {{ label }} </h1>
-      {{ degree_programme_switcher }}
-      {{ other_education_provider_switcher }}
-      {{ content|without('field_article_paragraph', 'field_article_related') }}
+    <div class="col-container">
+      <div class="col-left">
+        {{ link_to_instructions_for_students }}
+        {{ themes }}
+      </div>
+      <div class="col-main">
+        {{ degree_programme_switcher }}
+        {{ other_education_provider_switcher }}
+        {{ content|without('field_article_paragraph', 'field_article_related') }}
+      </div>
     </div>
   </div>
   {{ content.field_article_paragraph }}

--- a/themes/uhsg_theme/templates/paragraphs/paragraph--eduviewer.html.twig
+++ b/themes/uhsg_theme/templates/paragraphs/paragraph--eduviewer.html.twig
@@ -40,10 +40,9 @@
 {% if eduviewer is not empty %}
   <div {{ attributes.addClass('l-subregion-wrapper') }}>
     <div class="l-subregion col-container">
-      <div class="col-left">
-        <h3> {{ content.field_paragraph_title }} </h3>
-      </div>
+      <div class="col-left"></div>
       <div class="col-main">
+        <h3> {{ content.field_paragraph_title }} </h3>
         {{ eduviewer }}
       </div>
     </div>

--- a/themes/uhsg_theme/templates/paragraphs/paragraph--office-hours.html.twig
+++ b/themes/uhsg_theme/templates/paragraphs/paragraph--office-hours.html.twig
@@ -72,12 +72,11 @@
           {% for item in office_hours['general'] %}
             <div {{ attributes.addClass('textarea') }}>
               <div class="col-container">
-                <div class="col-left">
-                {% if item[0]['language'] is not empty %}
-                  <h3>{{ attribute(item[0]['language'].name, language) }}</h3>
-                {% endif %}
-                </div>
+                <div class="col-left"></div>
                 <div class="col-main">
+                  {% if item[0]['language'] is not empty %}
+                    <h3>{{ attribute(item[0]['language'].name, language) }}</h3>
+                  {% endif %}
                   {% for child_item in item %}
                     <h4>{{ child_item.name }}</h4>
                     <p>{{ child_item.hours|nl2br }}</p>

--- a/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
+++ b/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
@@ -39,16 +39,16 @@
 <div {{ attributes.addClass('l-subregion-wrapper') }}>
   <div class="l-subregion col-container">
     <div class="col-left">
-      <h3> {{ content.field_paragraph_title }} </h3>
       {{ content.field_paragraph_degree_programme }}
       {{ content.field_paragraph_faculty }}
       {{ content.field_paragraph_other_education }}
       {{ content.field_paragraph_image }}
       {{ content.field_paragraph_video }}
-      {{ content.field_paragraph_links }}
     </div>
     <div class="col-main">
+      <h3> {{ content.field_paragraph_title }} </h3>
       {{ content.field_paragraph_body }}
+      {{ content.field_paragraph_links }}
     </div>
   </div>
 </div>

--- a/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
+++ b/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
@@ -37,18 +37,25 @@
  */
 #}
 <div {{ attributes.addClass('l-subregion-wrapper') }}>
-  <div class="l-subregion col-container">
-    <div class="col-left">
-      {{ content.field_paragraph_degree_programme }}
-      {{ content.field_paragraph_faculty }}
-      {{ content.field_paragraph_other_education }}
-      {{ content.field_paragraph_image }}
-      {{ content.field_paragraph_video }}
-      {{ content.field_paragraph_links }}
+  <div class="l-subregion">
+    <div class="col-container">
+      <div class="col-left"></div>
+      <div class="col-main">
+        <h3> {{ content.field_paragraph_title }} </h3>
+      </div>
     </div>
-    <div class="col-main">
-      <h3> {{ content.field_paragraph_title }} </h3>
-      {{ content.field_paragraph_body }}
+    <div class="col-container">
+      <div class="col-left">
+        {{ content.field_paragraph_degree_programme }}
+        {{ content.field_paragraph_faculty }}
+        {{ content.field_paragraph_other_education }}
+        {{ content.field_paragraph_image }}
+        {{ content.field_paragraph_video }}
+        {{ content.field_paragraph_links }}
+      </div>
+      <div class="col-main">
+        {{ content.field_paragraph_body }}
+      </div>
     </div>
   </div>
 </div>

--- a/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
+++ b/themes/uhsg_theme/templates/paragraphs/paragraph--paragraph.html.twig
@@ -44,11 +44,11 @@
       {{ content.field_paragraph_other_education }}
       {{ content.field_paragraph_image }}
       {{ content.field_paragraph_video }}
+      {{ content.field_paragraph_links }}
     </div>
     <div class="col-main">
       <h3> {{ content.field_paragraph_title }} </h3>
       {{ content.field_paragraph_body }}
-      {{ content.field_paragraph_links }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR updates the layout and styles mainly for the Instruction node page, but does include some global changes:

- "The instruction belongs to the following themes" link list moved from right to left column, and list heading updated
- Anchor links moved from full page container to main column container to follow the main content flow
- Column widths and gutters updated to follow Studies service common styleguide
- Action button styles updated
- Paragraph headings moved from side column to main column