### PR TITLE
HUB-870: Updating the way we process the schacPersonalUniqueCode-attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.xx-dev
 Release date: ??.??.????
+* HUB-870 - Updating studentId attribute fetcher validation.
 
 ## 1.61
 Release date: 13.04.2021

--- a/modules/uhsg_samlauth/src/AttributeParser.php
+++ b/modules/uhsg_samlauth/src/AttributeParser.php
@@ -99,9 +99,8 @@ class AttributeParser implements AttributeParserInterface {
      * prior to return the actual value.
      */
     $value = (string) $value[0];
-    if (mb_strlen($value) > mb_strlen($this->studentIdPrefix)) {
-      // OK the value seems to have an sensible string length so return it
-      // without the expected prefix.
+    if (mb_strpos($value, $this->studentIdPrefix) === 0) {
+      // Value has a valid prefix so we're ok to return the id part.
       return substr($value, mb_strlen($this->studentIdPrefix));
     }
 


### PR DESCRIPTION
This PR updates the way we process the `schacPersonalUniqueCode`-attribute from samlauth. For now this attribute has always populated UH specific id values but that is about to change in the future. We need to make sure the value has a prefix of `urn:schac:personalUniqueCode:int:studentID:helsinki.fi:` before returning the id part.