### PR TITLE
HUB-872: Adding a missing sv translation for field_theme_articles label.

### DIFF
--- a/config/sync/language/sv/field.field.node.theme.field_theme_articles.yml
+++ b/config/sync/language/sv/field.field.node.theme.field_theme_articles.yml
@@ -1,0 +1,1 @@
+label: Instruktioner


### PR DESCRIPTION
Pushing a manual production change to code.